### PR TITLE
compile command fixes

### DIFF
--- a/src/commands/service/compile.ts
+++ b/src/commands/service/compile.ts
@@ -3,7 +3,7 @@ import yaml from 'js-yaml'
 import {join} from 'path'
 
 import deployer from '../../deployer'
-import Command, {Definition, Parameter} from '../../service-command'
+import Command, {CompiledDefinition, Parameter} from '../../service-command'
 import MarketplacePublish from '../marketplace/publish'
 
 export default class ServiceCompile extends Command {
@@ -21,7 +21,7 @@ export default class ServiceCompile extends Command {
     default: './'
   }]
 
-  async run(): Promise<Definition> {
+  async run(): Promise<CompiledDefinition> {
     const {args} = this.parse(ServiceCompile)
     this.spinner.status = 'Download sources'
     const path = await deployer(await this.processUrl(args.SERVICE_PATH_OR_URL))
@@ -32,7 +32,7 @@ export default class ServiceCompile extends Command {
     return definition
   }
 
-  parseYml(content: string, source: string): Definition {
+  parseYml(content: string, source: string): CompiledDefinition {
     const o = yaml.safeLoad(content)
     const parseParams = (params: any): Parameter[] => Object.keys(params)
       .map((key: string) => {

--- a/src/commands/service/compile.ts
+++ b/src/commands/service/compile.ts
@@ -64,7 +64,7 @@ export default class ServiceCompile extends Command {
       const versionHash = marketplaceUrl[1]
       const {type, source} = await this.getAuthorizedServiceInfo('', versionHash)
       if (type === 'ipfs') {
-        return `http://ipfs.app.mesg.com:8080/ipfs/${source}`
+        return `http://ipfs.app.mesg.com:8080/ipfs/${source}` // tslint:disable-line:no-http-string
       }
       throw new Error(`unknown protocol '${type}'`)
     }

--- a/src/commands/service/deploy.ts
+++ b/src/commands/service/deploy.ts
@@ -95,7 +95,7 @@ export default class ServiceDeploy extends Command {
     return x.service ? resolve(x.service) : reject(x.validationError)
   }
 
-  async processUrl(url: string): string {
+  async processUrl(url: string): Promise<string> {
     const marketplaceUrl = url.split('mesg://marketplace/service/')
     if (marketplaceUrl.length === 2) {
       const versionHash = marketplaceUrl[1]

--- a/src/commands/service/deploy.ts
+++ b/src/commands/service/deploy.ts
@@ -101,7 +101,7 @@ export default class ServiceDeploy extends Command {
       const versionHash = marketplaceUrl[1]
       const {type, source} = await this.getAuthorizedServiceInfo('', versionHash)
       if (type === 'ipfs') {
-        return `http://ipfs.app.mesg.com:8080/ipfs/${source}`
+        return `http://ipfs.app.mesg.com:8080/ipfs/${source}` // tslint:disable-line:no-http-string
       }
       throw new Error(`unknown protocol '${type}'`)
     }

--- a/src/service-command.ts
+++ b/src/service-command.ts
@@ -11,7 +11,7 @@ export interface Service {
   status: number
 }
 
-export interface Definition {
+export interface CompiledDefinition {
   sid: string
   name: string
   description: string
@@ -21,6 +21,10 @@ export interface Definition {
   configuration: Dependency
   repository: string
   source: string
+}
+
+export interface Definition extends CompiledDefinition {
+  hash: string
 }
 
 export interface Task {
@@ -75,7 +79,7 @@ export default abstract class extends Command {
     return ['unknown', 'stopped', 'starting', 'partial', 'running'][s]
   }
 
-  async getAuthorizedServiceInfo(id: string, versionHash: string): ServiceInfo {
+  async getAuthorizedServiceInfo(id: string, versionHash: string): Promise<ServiceInfo> {
     const list = await this.executeAndCaptureError(services.account.id, services.account.tasks.list)
     const {addresses} = list.data
     this.require(addresses.length > 0, 'you have no accounts. please add an authorized account in order to deploy this service')


### PR DESCRIPTION
- print and return the compiled object
- differentiate `Definition` and `CompiledDefinition` (compiled doesn't have hash)
- few fixes on method signatures
- fix linter