### PR TITLE
Pin source to ipfs node

### DIFF
--- a/src/commands/marketplace/publish.ts
+++ b/src/commands/marketplace/publish.ts
@@ -97,7 +97,7 @@ export default class MarketplacePublish extends Command {
   }
 
   private async upload(buffer: Buffer): Promise<string> {
-    const res = await this.IPFS.add(Buffer.from(buffer), {pin: false})
+    const res = await this.IPFS.add(Buffer.from(buffer), {pin: true})
     if (!res.length) {
       throw new Error('Error with the generation of your manifest')
     }


### PR DESCRIPTION
check out more about pinning https://docs.ipfs.io/guides/concepts/pinning/

It was set to no pinning because we infura was not supporting it, now we have our own node that supports it