### PR TITLE
Update mesg lib

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3846,9 +3846,9 @@
       "dev": true
     },
     "mesg-js": {
-      "version": "2.1.0",
-      "resolved": "https://registry.npmjs.org/mesg-js/-/mesg-js-2.1.0.tgz",
-      "integrity": "sha512-mVK9dzsgBrvwb6PaZaBL/XcThbo1G2weTPS7aimPeRIW+z5D1q3MBGKhOu/EsLL78SA4HNDyXq0USq8W6Dn7IA==",
+      "version": "3.0.0-beta.0",
+      "resolved": "https://registry.npmjs.org/mesg-js/-/mesg-js-3.0.0-beta.0.tgz",
+      "integrity": "sha512-n/EaOHpogTFJRCr/5gCzFhFBPHFXHX4k4AWHHaZjOEsO/tLSWnJJ03tWupJ6EsXNjNjj0jp9n7qQdzfGfXkfdg==",
       "requires": {
         "@grpc/proto-loader": "^0.3.0",
         "clone": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "ipfs-http-client": "^29.1.1",
     "is-git-url": "^1.0.0",
     "js-yaml": "^3.13.1",
-    "mesg-js": "^2.1.0",
+    "mesg-js": "^3.0.0-beta.0",
     "node-docker-api": "^1.1.22",
     "rimraf": "^2.6.3",
     "tar": "^4.4.8",


### PR DESCRIPTION
With the actual version of mesg-js we have the following errors:

```
Error: 13 INTERNAL: Failed to parse server response
    at Object.exports.createStatusError (~/prog/MESG/cli/node_modules/grpc/src/common.js:91:15)
    at Object.onReceiveStatus (~/prog/MESG/cli/node_modules/grpc/src/client_interceptors.js:1204:28)
    at InterceptingListener._callNext (~/prog/MESG/cli/node_modules/grpc/src/client_interceptors.js:568:42)
    at InterceptingListener.onReceiveStatus (~/prog/MESG/cli/node_modules/grpc/src/client_interceptors.js:618:8)
    at callback (~/prog/MESG/cli/node_modules/grpc/src/client_interceptors.js:845:24)
```

Updating this to the new lib