### PR TITLE
Manage error response from an execution

### DIFF
--- a/src/commands/service/deploy.ts
+++ b/src/commands/service/deploy.ts
@@ -1,9 +1,9 @@
 import {flags} from '@oclif/command'
 import {existsSync, readdirSync, readFileSync} from 'fs'
+import ignore from 'ignore'
 import {join} from 'path'
 import {Readable, Writable} from 'stream'
 import tar from 'tar'
-import ignore from 'ignore'
 
 import deployer from '../../deployer'
 import Command, {ServiceID} from '../../service-command'

--- a/src/commands/service/execute.ts
+++ b/src/commands/service/execute.ts
@@ -44,7 +44,7 @@ export default class ServiceExecute extends Command {
     }
     const inputs = this.convertValue(task.inputs, this.dataFromFlags(flags))
 
-    const result = await this.execute(service.definition.hash, args.TASK, inputs)
+    const result = await this.executeAndCaptureError(service.definition.hash, args.TASK, inputs)
     this.log(`Result of task ${args.TASK}`)
     this.styledJSON(result.data)
     return result

--- a/src/root-command.ts
+++ b/src/root-command.ts
@@ -94,24 +94,22 @@ export default abstract class extends Command {
     cli.styledJSON(data)
   }
 
-  async execute(serviceID: string, taskKey: string, data: object = {}, tags: string[] = []): Promise<ExecutionResult> {
+  async executeAndCaptureError(serviceID: string, taskKey: string, data: object = {}, tags: string[] = []): Promise<ExecutionResult> {
     this.debug(`Execute task ${taskKey} from ${serviceID} with ${JSON.stringify(data)}`)
-    const result = await this.mesg.executeTaskAndWaitResult({
-      serviceID,
-      taskKey,
-      inputData: JSON.stringify(data),
-      executionTags: [...tags, 'cli']
-    })
-    this.debug(`Receiving result of ${result.executionID}, ${result.taskKey} => ${result.outputData}`)
-    return {
-      data: JSON.parse(result.outputData)
-    }
-  }
-
-  async executeAndCaptureError(serviceID: string, taskKey: string, data: object = {}): Promise<ExecutionResult> {
     try {
-      const result = await this.execute(serviceID, taskKey, data)
-      return result
+      const result = await this.mesg.executeTaskAndWaitResult({
+        serviceID,
+        taskKey,
+        inputData: JSON.stringify(data),
+        executionTags: [...tags, 'cli']
+      })
+      this.debug(`Receiving result of ${result.executionID}, ${result.taskKey} => ${result.outputData}`)
+      if (result.error) {
+        throw new Error(result.error)
+      }
+      return {
+        data: JSON.parse(result.outputData)
+      }
     } catch (e) {
       this.error(e.message)
       throw new Error(e.message)


### PR DESCRIPTION
fix https://github.com/mesg-foundation/cli/issues/56

- use a single function to execute and watch for error