### PR TITLE
commands/service:compile: support compiling workflows in service definition

### DIFF
--- a/src/commands/service/compile.ts
+++ b/src/commands/service/compile.ts
@@ -54,7 +54,11 @@ export default class ServiceCompile extends Command {
       dependencies: Object.keys(o.dependencies || {}).map((key: string) => ({key, ...o.dependencies[key]})),
       configuration: o.configuration,
       repository: o.repository,
-      source
+      source,
+      workflows: Object.keys(o.workflows || {}).map((key: string) => {
+        const {trigger, tasks} = o.workflows[key]
+        return {key, trigger, tasks}
+      }),
     }
   }
 

--- a/src/protobuf/definition/service.proto
+++ b/src/protobuf/definition/service.proto
@@ -15,6 +15,7 @@ message Service {
   repeated Dependency dependencies = 7;     // The container dependencies this service requires.
   string repository = 9;                    // Service's repository url.
   string source = 13;                       // The hash id of service's source code on IPFS.
+  repeated Workflow workflows = 14;         // Service's workflows.
 }
 
 // Events are emitted by the service whenever the service wants.
@@ -63,4 +64,29 @@ message Dependency {
   repeated string ports = 4;        // List of ports the container exposes.
   repeated string args = 6;         // Args to pass to the container.
   string command = 5;               // Command to run the container.
+}
+
+// Workflow represents the workflow's definition.
+message Workflow {
+  // Trigger keeps the conditions to match in order to start workflow.
+  message Trigger {
+    string instanceHash = 1;  // instanceHash is the hash of instance to match.
+    string eventKey = 2;      // evenkey is the event key on instance to match.
+    Filter filter = 3;        // filter keeps additional conditions to match.
+  }
+
+  // Filter keeps additional conditions for trigger.
+  message Filter {
+    string taskKey = 1;
+  }
+
+  // Task represents a task to execute when conditions are met.
+  message Task {
+    string instanceHash = 1;  // instanceHash is the hash of instance to execute a task on.
+    string key = 2;           // key is the key of task to execute on instance.
+  }
+
+  string key = 1;           // Workflow's key.
+  Trigger trigger = 2;      // trigger keeps the conditions to match in order to start workflow.
+  repeated Task tasks = 3;  // tasks to execute in order by using previous one's outputs as next one's inputs.
 }

--- a/src/service-command.ts
+++ b/src/service-command.ts
@@ -21,6 +21,7 @@ export interface CompiledDefinition {
   configuration: Dependency
   repository: string
   source: string
+  workflows: Workflow[]
 }
 
 export interface Definition extends CompiledDefinition {
@@ -60,6 +61,20 @@ export interface Parameter {
   optional: boolean
   repeated: boolean
   object: Parameter[]
+}
+
+export interface Workflow {
+  trigger: {
+    instanceHash: string
+    eventKey: string
+    filter: {
+      taskKey: string
+    }
+  }
+  tasks: [{
+    instanceHash: string
+    key: string
+  }]
 }
 
 export type SERVICE_PARAMETER_TYPE = 'String' | 'Number' | 'Boolean' | 'Object' | 'Any'


### PR DESCRIPTION
```
{
  "sid": "ethereum-erc20",
  "name": "Ethereum ERC20 token",
  "tasks": [
    {
      "key": "name",
      "name": "Token's name",
      "description": "Get the name of a ERC20",
      "inputs": [
        {
          "key": "contractAddress",
          "type": "String",
          "object": []
        }
      ],
      "outputs": [
        {
          "key": "name",
          "name": "Token's name",
          "description": "The name of the ERC20",
          "type": "String",
          "object": []
        }
      ]
    }
  ],
  "events": [],
  "dependencies": [],
  "source": "QmRikPiRTkm1PConjWjvHfTxiPnUeQ3rVeUvL9maB5pEZR",
  "workflows": [
    {
      "key": "workflowA",
      "trigger": {
        "instanceHash": "serviceA",
        "eventKey": "eventX"
      },
      "tasks": [
        {
          "instanceHash": "serviceB",
          "key": "task1"
        },
        {
          "instanceHash": "serviceC",
          "key": "task2"
        },
        {
          "instanceHash": "serviceF",
          "key": "task5"
        }
      ]
    },
    {
      "key": "workflowB",
      "trigger": {
        "instanceHash": "serviceB",
        "eventKey": "executionFinished",
        "filter": {
          "taskKey": "task1"
        }
      },
      "tasks": [
        {
          "instanceHash": "serviceD",
          "key": "task3"
        }
      ]
    },
    {
      "key": "workflowC",
      "trigger": {
        "instanceHash": "serviceB",
        "eventKey": "executionFinished",
        "filter": {
          "taskKey": "task1"
        }
      }
    }
  ]
}
```