### PR TITLE
Better management of confirm flag with delete data only

### DIFF
--- a/src/commands/service/start.ts
+++ b/src/commands/service/start.ts
@@ -22,7 +22,7 @@ export default class ServiceStart extends Command {
 
   async run(): InstanceCreateOutputs {
     const {args, flags} = this.parse(ServiceStart)
-    this.spinner.start('Start service')
+    this.spinner.start('Start instance')
     const instance = await this.api.instance.create({
       serviceHash: args.SERVICE_HASH,
       env: flags.env

--- a/src/commands/service/stop.ts
+++ b/src/commands/service/stop.ts
@@ -12,7 +12,11 @@ export default class ServiceStop extends Command {
       description: 'Delete instances\' persistent data',
       default: false,
     }),
-    confirm: flags.boolean({description: 'Confirm delete', default: false})
+    confirm: flags.boolean({
+      description: 'Confirm delete',
+      default: false,
+      dependsOn: ['delete-data']
+    })
   }
 
   static strict = false
@@ -24,10 +28,10 @@ export default class ServiceStop extends Command {
 
   async run(): Promise<string[]> {
     const {argv, flags} = this.parse(ServiceStop)
-    if (flags['delete-data']) {
+    if (flags['delete-data'] && !flags.confirm) {
       cli.warn('This will delete all data associated to this instance')
+      if (!await cli.confirm('Are you sure?')) return []
     }
-    if (!flags.confirm && !await cli.confirm('Are you sure?')) return []
     this.spinner.start('Delete instance')
     for (const hash of argv) {
       this.spinner.status = hash


### PR DESCRIPTION
dependency: https://github.com/mesg-foundation/cli/pull/81

`--confirm` flag is only needed when `--delete-data` is present on `service:stop` command.
warning message only displays if `--confirm` is not set