### PR TITLE
Add start flag to command create

### DIFF
--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -1,12 +1,19 @@
+import {flags} from '@oclif/command'
 import {ServiceCreateOutputs} from 'mesg-js/lib/api'
 
 import Command from '../../root-command'
+
+import ServiceStart from './start'
 
 export default class ServiceCreate extends Command {
   static description = 'Create a service'
 
   static flags = {
     ...Command.flags,
+    start: flags.boolean({
+      description: 'Automatically start the service once created',
+      default: false,
+    })
   }
 
   static args = [{
@@ -16,11 +23,16 @@ export default class ServiceCreate extends Command {
   }]
 
   async run(): ServiceCreateOutputs {
-    const {args} = this.parse(ServiceCreate)
+    const {args, flags} = this.parse(ServiceCreate)
     this.spinner.start('Create service')
     const resp = await this.api.service.create(JSON.parse(args.DEFINITION))
     if (!resp.hash) { throw new Error('invalid response') }
     this.spinner.stop(resp.hash)
+    if (flags.start) {
+      this.spinner.start('Create service')
+      const start = await ServiceStart.run([resp.hash])
+      this.spinner.stop(start.hash)
+    }
     return resp
   }
 }

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -29,7 +29,7 @@ export default class ServiceCreate extends Command {
     if (!resp.hash) { throw new Error('invalid response') }
     this.spinner.stop(resp.hash)
     if (flags.start) {
-      this.spinner.start('Create service')
+      this.spinner.start('Starting service')
       const start = await ServiceStart.run([resp.hash])
       this.spinner.stop(start.hash)
     }


### PR DESCRIPTION
fix https://github.com/mesg-foundation/cli/issues/9

We can now use the flag `--start` to automatically start the service once create.

`mesg-cli service:create "$(cat service.json)" --start`