### PR TITLE
fix issue when no instances are running

### DIFF
--- a/src/commands/service/list.ts
+++ b/src/commands/service/list.ts
@@ -21,7 +21,7 @@ export default class ServiceList extends Command {
       sid: {header: 'SID', get: x => x.sid},
       instances: {
         header: 'INSTANCES',
-        get: x => (instances as Instance[])
+        get: x => ((instances || []) as Instance[])
           .filter(y => y.serviceHash === x.hash)
           .map(y => y.hash)
           .join('\n')


### PR DESCRIPTION
When running `service:list` command and no services are running we got an error because grpc doesn't return empty array but undefined value when there is no data