### PR TITLE
Add workflow compilation

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ USAGE
 * [`mesg-cli service:logs INSTANCE_HASH`](#mesg-cli-servicelogs-instance_hash)
 * [`mesg-cli service:start SERVICE_HASH`](#mesg-cli-servicestart-service_hash)
 * [`mesg-cli service:stop INSTANCE_HASH...`](#mesg-cli-servicestop-instance_hash)
+* [`mesg-cli workflow:compile [WORKFLOW_FILE]`](#mesg-cli-workflowcompile-workflow_file)
 
 ## `mesg-cli account:create`
 
@@ -538,4 +539,22 @@ OPTIONS
 ```
 
 _See code: [src/commands/service/stop.ts](https://github.com/mesg-foundation/cli/blob/v1.2.0/src/commands/service/stop.ts)_
+
+## `mesg-cli workflow:compile [WORKFLOW_FILE]`
+
+Compile a workflow
+
+```
+USAGE
+  $ mesg-cli workflow:compile [WORKFLOW_FILE]
+
+ARGUMENTS
+  WORKFLOW_FILE  Path of a workflow file
+
+OPTIONS
+  -h, --help   show CLI help
+  -q, --quiet  Display only essential information
+```
+
+_See code: [src/commands/workflow/compile.ts](https://github.com/mesg-foundation/cli/blob/v1.2.0/src/commands/workflow/compile.ts)_
 <!-- commandsstop -->

--- a/package.json
+++ b/package.json
@@ -88,6 +88,9 @@
       "service": {
         "description": "Manage services"
       },
+      "workflow": {
+        "description": "Manage workflows"
+      },
       "daemon": {
         "description": "Manage the Engine"
       },

--- a/src/commands/service/compile.ts
+++ b/src/commands/service/compile.ts
@@ -5,7 +5,7 @@ import {join} from 'path'
 import {WithoutPassphrase} from '../../account-command'
 import MarketplaceCommand from '../../marketplace-command'
 import Command from '../../root-command'
-import compile from '../../utils/compiler'
+import * as compile from '../../utils/compiler'
 import deployer, {createTar} from '../../utils/deployer'
 
 const ipfsClient = require('ipfs-http-client')
@@ -29,7 +29,7 @@ export default class ServiceCompile extends Command {
     const {args} = this.parse(ServiceCompile)
     this.spinner.status = 'Download sources'
     const path = await deployer(await this.processUrl(args.SERVICE))
-    const definition = await compile(readFileSync(join(path, 'mesg.yml')))
+    const definition = await compile.service(readFileSync(join(path, 'mesg.yml')))
     definition.source = await this.deploySources(path)
     this.styledJSON(definition)
     this.spinner.stop()

--- a/src/commands/workflow/compile.ts
+++ b/src/commands/workflow/compile.ts
@@ -1,0 +1,25 @@
+import {readFileSync} from 'fs'
+
+import Command from '../../root-command'
+import * as compile from '../../utils/compiler'
+
+export default class WorkflowCompile extends Command {
+  static description = 'Compile a workflow'
+
+  static flags = {
+    ...Command.flags
+  }
+
+  static args = [{
+    name: 'WORKFLOW_FILE',
+    description: 'Path of a workflow file'
+  }]
+
+  async run(): Promise<any> {
+    const {args} = this.parse(WorkflowCompile)
+    const definition = await compile.workflow(readFileSync(args.WORKFLOW_FILE))
+    this.styledJSON(definition)
+    this.spinner.stop()
+    return definition
+  }
+}

--- a/src/utils/compiler.ts
+++ b/src/utils/compiler.ts
@@ -14,7 +14,7 @@ const parseParams = (params: any): any => mapToArray(params).map(x => ({
   object: parseParams(x.object),
 }))
 
-export default async (content: Buffer): Promise<Service> => {
+export const service = async (content: Buffer): Promise<Service> => {
   const definition = decode(content)
   return {
     ...pick(definition, ['sid', 'name', 'description', 'configuration', 'repository']),
@@ -27,7 +27,9 @@ export default async (content: Buffer): Promise<Service> => {
     events: mapToArray(definition.events).map(x => ({
       ...pick(x, ['key', 'name', 'description']),
       data: parseParams(x.data)
-    })),
-    workflows: mapToArray(definition.workflows).map(x => pick(x, ['key', 'trigger', 'task']))
+    }))
+  }
+}
+
   }
 }

--- a/src/utils/compiler.ts
+++ b/src/utils/compiler.ts
@@ -1,6 +1,7 @@
 import yaml from 'js-yaml'
 import pick from 'lodash.pick'
-import {Service} from 'mesg-js/lib/api/types'
+import * as WorkflowType from 'mesg-js/lib/api/typedef/workflow'
+import {Service, Workflow} from 'mesg-js/lib/api/types'
 
 const decode = (content: Buffer) => yaml.safeLoad(content.toString())
 
@@ -13,6 +14,10 @@ const parseParams = (params: any): any => mapToArray(params).map(x => ({
   ...pick(x, ['key', 'name', 'description', 'type', 'repeated', 'optional']),
   object: parseParams(x.object),
 }))
+
+const prepareInstanceHash = async (object: any): Promise<string> => {
+  return object.instanceHash
+}
 
 export const service = async (content: Buffer): Promise<Service> => {
   const definition = decode(content)
@@ -31,5 +36,34 @@ export const service = async (content: Buffer): Promise<Service> => {
   }
 }
 
+export const workflow = async (content: Buffer): Promise<Workflow> => {
+  const definition = decode(content)
+  const createNode = async (def: any, index: number): Promise<WorkflowType.types.Workflow.INode> => ({
+    key: def.key || `node-${index}`,
+    taskKey: def.taskKey,
+    instanceHash: await prepareInstanceHash(def)
+  })
+  const orderedNodes = await Promise.all(definition.tasks.map(createNode)) as WorkflowType.types.Workflow.INode[]
+
+  const trigger = {
+    instanceHash: await prepareInstanceHash(definition.trigger),
+    taskKey: definition.trigger.taskKey,
+    eventKey: definition.trigger.eventKey,
+    nodeKey: orderedNodes[0].key
+  }
+
+  const edges: any[] = []
+  for (let i = 0; i < orderedNodes.length - 1; i++) {
+    edges.push({
+      src: orderedNodes[i].key,
+      dst: orderedNodes[i + 1].key
+    })
+  }
+
+  return {
+    key: definition.key,
+    trigger,
+    nodes: orderedNodes,
+    edges,
   }
 }


### PR DESCRIPTION
Add compilation of workflow file with the CLI with a new command

```
mesg-cli workflow:compile FILE
```

A workflow file is a `yml` file with the following definition:
```yaml
key: xxx                 # key to identify the workflow (required)
trigger:                 # trigger that starts the workflow
  instanceHash: xxx      # hash of the service's instance (required)
  eventKey: xxx          # key of the event to listen (required if taskKey is not set)
  taskKey: xxx           # key of the task to listen (required if eventKey is not set)
tasks:                   # list of tasks to execute
  - key: xxx             # key to identify the task (optional, default `node-${index}`
    instanceHash: xxx    # service's instance to execute
    taskKey: xxx         # task to execute
  - instanceHash:  xxx   # service's instance to execute
    taskKey: xxx         # task to execute
  - ...
```

The CLI will generate the associated graph based on the order of the tasks.

**Test:**

You can use the following definition:
```yaml
key: Event
trigger:
  instanceHash: 88YtHw3iZtjpAeDDUWHsDFg9MLvgircPzCFHxFqJ2ex9
  eventKey: eventX
tasks:
  - instanceHash: 8qKUdaMPAn35ozeUWVcT9BQ5gHNJYbJJ5rTCWqfnJgpW
    taskKey: taskY
  - instanceHash: 7sTRCDpWCXYBSVgh7dKKV6pP69PHdYQY8kyBohumEWNu
    taskKey: taskZ
```

This should generate the following workflow definition
```json
{
  "key": "Event",
  "trigger": {
    "instanceHash": "88YtHw3iZtjpAeDDUWHsDFg9MLvgircPzCFHxFqJ2ex9",
    "eventKey": "eventX",
    "nodeKey": "node-0"
  },
  "nodes": [
    {
      "key": "node-0",
      "taskKey": "taskY",
      "instanceHash": "8qKUdaMPAn35ozeUWVcT9BQ5gHNJYbJJ5rTCWqfnJgpW"
    },
    {
      "key": "node-1",
      "taskKey": "taskZ",
      "instanceHash": "7sTRCDpWCXYBSVgh7dKKV6pP69PHdYQY8kyBohumEWNu"
    }
  ],
  "edges": [
    {
      "src": "node-0",
      "dst": "node-1"
    }
  ]
}
```

**Next things to do:**
- Add support of service resolution based on SID and not only instanceHash
```
tasks:
  - service: service-id
```
- Add deployment of services from the workflow
```
tasks:
  - service: ./
  - service: https://github.com/....
  - service: mesg://xxxxx
```