### PR TITLE
Service resolution for the workflow

### DIFF
--- a/src/commands/workflow/compile.ts
+++ b/src/commands/workflow/compile.ts
@@ -36,7 +36,7 @@ export default class WorkflowCompile extends Command {
     const {services} = await this.api.service.list({})
     if (!services) throw new Error('no services deployed, please deploy your service first')
     const match = services.filter(x => x.hash === key || x.sid === key)
-    if (!match || match.length === 0) throw new Error(`cannot find any service with the following key: ${key}`)
+    if (!match || match.length === 0) throw new Error(`cannot find any service with the following: ${key}`)
     if (match.length > 1) throw new Error(`multiple services match the following sid: ${key}, provide a service's hash instead`)
     const service = match[0]
     if (!service.hash) throw new Error('invalid service')

--- a/src/commands/workflow/compile.ts
+++ b/src/commands/workflow/compile.ts
@@ -36,6 +36,7 @@ export default class WorkflowCompile extends Command {
     const {services} = await this.api.service.list({})
     if (!services) throw new Error('no services deployed, please deploy your service first')
     const match = services.filter(x => x.hash === key || x.sid === key)
+    if (!match || match.length === 0) throw new Error(`cannot find any service with the following key: ${key}`)
     if (match.length > 1) throw new Error(`multiple services match the following sid: ${key}, provide a service's hash instead`)
     const service = match[0]
     if (!service.hash) throw new Error('invalid service')

--- a/src/commands/workflow/compile.ts
+++ b/src/commands/workflow/compile.ts
@@ -2,6 +2,7 @@ import {readFileSync} from 'fs'
 
 import Command from '../../root-command'
 import * as compile from '../../utils/compiler'
+import ServiceStart from '../service/start';
 
 export default class WorkflowCompile extends Command {
   static description = 'Compile a workflow'
@@ -17,9 +18,35 @@ export default class WorkflowCompile extends Command {
 
   async run(): Promise<any> {
     const {args} = this.parse(WorkflowCompile)
-    const definition = await compile.workflow(readFileSync(args.WORKFLOW_FILE))
+    const definition = await compile.workflow(readFileSync(args.WORKFLOW_FILE), async (instanceObject: any) => {
+      if (instanceObject.instanceHash) {
+        return instanceObject.instanceHash
+      }
+      if (instanceObject.service) {
+        return this.serviceToInstance(instanceObject.service)
+      }
+      throw new Error('instance resolution error')
+    })
     this.styledJSON(definition)
     this.spinner.stop()
     return definition
+  }
+
+  async serviceToInstance(key: string): Promise<string> {
+    const {services} = await this.api.service.list({})
+    if (!services) throw new Error('no services deployed, please deploy your service first')
+    const match = services.filter(x => x.hash === key || x.sid === key)
+    if (match.length > 1) throw new Error(`multiple services match the following key: ${key}, please use service Hash instead.`)
+    const service = match[0]
+    if (!service.hash) throw new Error('invalid service')
+    const {instances} = await this.api.instance.list({serviceHash: service.hash})
+    if (!instances || instances.length === 0) {
+      const instance = await ServiceStart.run([service.hash, '--silent'])
+      return instance.hash
+    }
+    if (instances.length > 1) throw new Error('multiple instances running, please use instanceHash instead.')
+    const instance = instances[0]
+    if (!instance.hash) throw new Error('invalid instance')
+    return instance.hash
   }
 }

--- a/src/commands/workflow/compile.ts
+++ b/src/commands/workflow/compile.ts
@@ -25,7 +25,7 @@ export default class WorkflowCompile extends Command {
       if (instanceObject.service) {
         return this.serviceToInstance(instanceObject.service)
       }
-      throw new Error('instance resolution error')
+      throw new Error('at least one of the following parameter should be set: "instanceHash" or "service"')
     })
     this.styledJSON(definition)
     this.spinner.stop()
@@ -36,7 +36,7 @@ export default class WorkflowCompile extends Command {
     const {services} = await this.api.service.list({})
     if (!services) throw new Error('no services deployed, please deploy your service first')
     const match = services.filter(x => x.hash === key || x.sid === key)
-    if (match.length > 1) throw new Error(`multiple services match the following key: ${key}, please use service Hash instead.`)
+    if (match.length > 1) throw new Error(`multiple services match the following sid: ${key}, provide a service's hash instead`)
     const service = match[0]
     if (!service.hash) throw new Error('invalid service')
     const {instances} = await this.api.instance.list({serviceHash: service.hash})
@@ -44,7 +44,7 @@ export default class WorkflowCompile extends Command {
       const instance = await ServiceStart.run([service.hash, '--silent'])
       return instance.hash
     }
-    if (instances.length > 1) throw new Error('multiple instances running, please use instanceHash instead.')
+    if (instances.length > 1) throw new Error('multiple instances match the service, use parameter "instanceHash" instead of "service"')
     const instance = instances[0]
     if (!instance.hash) throw new Error('invalid instance')
     return instance.hash


### PR DESCRIPTION
Instead of defining an `instanceHash` workflows now accept `service` that can be the service `hash` or `sid`.

If the instance is present then we use the instance otherwise we use the service and test that the service exists. If it exists then we get the instance of this service (throw an error if there are multiple instances), otherwise, we start a new instance of this service.

This doesn't support the creation of an instance with predefined envs yet.