### PR TITLE
Do not raise an error when a service is already started

### DIFF
--- a/src/commands/service/start.ts
+++ b/src/commands/service/start.ts
@@ -26,22 +26,26 @@ export default class ServiceStart extends Command {
     const {args, flags} = this.parse(ServiceStart)
     this.spinner.start('Start instance')
     const serviceHash = await serviceResolver(this.api, args.SERVICE_HASH)
-    const instance = await this.api.instance.create({
-      serviceHash,
-      env: flags.env
-    })
-    if (!instance.hash) throw new Error('invalid instance')
-    this.spinner.stop(instance.hash)
-    return instance
+    try {
+      const instance = await this.api.instance.create({
+        serviceHash,
+        env: flags.env
+      })
+      if (!instance.hash) throw new Error('invalid instance')
+      this.spinner.stop(instance.hash)
+      return instance
+    } catch (err) {
+      return this.handleError(err)
+    }
   }
 
-  async catch(err: Error): Promise<any> {
+  handleError(err: Error) {
     if (isAlreadyExists(err, 'instance')) {
       const hash = resourceHash(err, 'instance')
       this.warn(`instance ${hash} already started`)
       this.spinner.stop(hash)
       return {hash}
     }
-    return super.catch(err)
+    throw err
   }
 }

--- a/src/commands/service/start.ts
+++ b/src/commands/service/start.ts
@@ -2,7 +2,7 @@ import {flags} from '@oclif/command'
 import {InstanceCreateOutputs} from 'mesg-js/lib/api'
 
 import Command from '../../root-command'
-import {isAlreadyExists, resourceHash} from '../../utils/error'
+import {errorConversion} from '../../utils/error'
 import serviceResolver from '../../utils/service-resolver'
 
 export default class ServiceStart extends Command {
@@ -35,17 +35,7 @@ export default class ServiceStart extends Command {
       this.spinner.stop(instance.hash)
       return instance
     } catch (err) {
-      return this.handleError(err)
+      throw errorConversion(err)
     }
-  }
-
-  handleError(err: Error) {
-    if (isAlreadyExists(err, 'instance')) {
-      const hash = resourceHash(err, 'instance')
-      this.warn(`instance ${hash} already started`)
-      this.spinner.stop(hash)
-      return {hash}
-    }
-    throw err
   }
 }

--- a/src/commands/service/start.ts
+++ b/src/commands/service/start.ts
@@ -2,6 +2,7 @@ import {flags} from '@oclif/command'
 import {InstanceCreateOutputs} from 'mesg-js/lib/api'
 
 import Command from '../../root-command'
+import {isAlreadyExists, resourceHash} from '../../utils/error'
 import serviceResolver from '../../utils/service-resolver'
 
 export default class ServiceStart extends Command {
@@ -32,5 +33,15 @@ export default class ServiceStart extends Command {
     if (!instance.hash) throw new Error('invalid instance')
     this.spinner.stop(instance.hash)
     return instance
+  }
+
+  async catch(err: Error): Promise<any> {
+    if (isAlreadyExists(err, 'instance')) {
+      const hash = resourceHash(err, 'instance')
+      this.warn(`instance ${hash} already started`)
+      this.spinner.stop(hash)
+      return {hash}
+    }
+    return super.catch(err)
   }
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,0 +1,11 @@
+export const isAlreadyExists = (err: Error, resource: string): boolean => {
+  const reg = new RegExp(`${resource} \"(.*)\" already exists`)
+  return reg.test(err.message)
+}
+
+export const resourceHash = (err: Error, resource: string): string => {
+  const reg = new RegExp(`${resource} \"(.*)\" already exists`)
+  const res = reg.exec(err.message)
+  if (!res) return ''
+  return res[1]
+}

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,11 +1,24 @@
-export const isAlreadyExists = (err: Error, resource: string): boolean => {
-  const reg = new RegExp(`${resource} \"(.*)\" already exists`)
-  return reg.test(err.message)
+export class IsAlreadyExistsError extends Error {
+  static ID = 'ALREADY_EXISTS'
+  static regexp = new RegExp('\"(.*)\" already exists')
+  static match(err: Error) {
+    return IsAlreadyExistsError.regexp.test(err.message)
+  }
+
+  hash: string
+
+  constructor(error: Error) {
+    super(error.message)
+    const res = IsAlreadyExistsError.regexp.exec(error.message)
+    const hash = res && res.length >= 1 ? res[1] : ''
+    this.hash = hash
+    this.name = IsAlreadyExistsError.ID
+  }
 }
 
-export const resourceHash = (err: Error, resource: string): string => {
-  const reg = new RegExp(`${resource} \"(.*)\" already exists`)
-  const res = reg.exec(err.message)
-  if (!res) return ''
-  return res[1]
+export const errorConversion = (err: Error): Error => {
+  if (IsAlreadyExistsError.match(err)) {
+    return new IsAlreadyExistsError(err)
+  }
+  return err
 }


### PR DESCRIPTION
When a service is started and we execute the command `service:start` we have an error.

Now the command will catch the error, display a warning and return the hash based on the error.