### PR TITLE
Simplify error management

### DIFF
--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -2,7 +2,6 @@ import {flags} from '@oclif/command'
 import {ServiceCreateOutputs} from 'mesg-js/lib/api'
 
 import Command from '../../root-command'
-import {errorConversion} from '../../utils/error'
 
 import ServiceStart from './start'
 
@@ -26,12 +25,7 @@ export default class ServiceCreate extends Command {
   async run(): ServiceCreateOutputs {
     const {args, flags} = this.parse(ServiceCreate)
     this.spinner.start('Create service')
-    let resp: any
-    try {
-      resp = await this.api.service.create(JSON.parse(args.DEFINITION))
-    } catch (e) {
-      throw errorConversion(e)
-    }
+    const resp = await this.api.service.create(JSON.parse(args.DEFINITION))
     if (!resp.hash) { throw new Error('invalid response') }
     this.spinner.stop(resp.hash)
     if (flags.start) {

--- a/src/commands/service/start.ts
+++ b/src/commands/service/start.ts
@@ -2,7 +2,6 @@ import {flags} from '@oclif/command'
 import {InstanceCreateOutputs} from 'mesg-js/lib/api'
 
 import Command from '../../root-command'
-import {errorConversion} from '../../utils/error'
 import serviceResolver from '../../utils/service-resolver'
 
 export default class ServiceStart extends Command {
@@ -26,16 +25,12 @@ export default class ServiceStart extends Command {
     const {args, flags} = this.parse(ServiceStart)
     this.spinner.start('Start instance')
     const serviceHash = await serviceResolver(this.api, args.SERVICE_HASH)
-    try {
-      const instance = await this.api.instance.create({
-        serviceHash,
-        env: flags.env
-      })
-      if (!instance.hash) throw new Error('invalid instance')
-      this.spinner.stop(instance.hash)
-      return instance
-    } catch (err) {
-      throw errorConversion(err)
-    }
+    const instance = await this.api.instance.create({
+      serviceHash,
+      env: flags.env
+    })
+    if (!instance.hash) throw new Error('invalid instance')
+    this.spinner.stop(instance.hash)
+    return instance
   }
 }

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -15,10 +15,3 @@ export class IsAlreadyExistsError extends Error {
     this.name = IsAlreadyExistsError.ID
   }
 }
-
-export const errorConversion = (err: Error): Error => {
-  if (IsAlreadyExistsError.match(err)) {
-    return new IsAlreadyExistsError(err)
-  }
-  return err
-}


### PR DESCRIPTION
https://github.com/mesg-foundation/cli/pull/131 introduced a wrapping of the error for the commands service start/create but unfortunately this is not useful because the cli overrides the error with its own CLI error.

This removes the useless code but still keep the error to still be able to detect the error