### PR TITLE
Better error management for dev command

### DIFF
--- a/src/commands/service/dev.ts
+++ b/src/commands/service/dev.ts
@@ -1,4 +1,7 @@
+import {Service} from 'mesg-js/lib/api'
+
 import Command from '../../root-command'
+import {IsAlreadyExistsError} from '../../utils/error'
 
 import ServiceCompile from './compile'
 import ServiceCreate from './create'
@@ -26,15 +29,41 @@ export default class ServiceDev extends Command {
     const {args, flags} = this.parse(ServiceDev)
 
     const definition = await ServiceCompile.run([args.SERVICE, '--silent'])
-    const service = await ServiceCreate.run([JSON.stringify(definition)])
-    const envs = (flags.env || []).reduce((prev, value) => [...prev, '--env', value], [] as string[])
-    const instance = await ServiceStart.run([service.hash, ...envs])
-    const stream = await ServiceLog.run([instance.hash])
+    const serviceHash = await this.createService(definition)
+    const instanceHash = await this.startService(serviceHash, flags.env)
+    const stream = await ServiceLog.run([instanceHash])
 
     process.once('SIGINT', async () => {
       stream.destroy()
-      await ServiceStop.run([instance.hash])
-      await ServiceDelete.run([service.hash, '--confirm'])
+      await ServiceStop.run([instanceHash])
+      await ServiceDelete.run([serviceHash, '--confirm'])
     })
+  }
+
+  async createService(definition: Service): Promise<string> {
+    try {
+      const service = await this.api.service.create(definition)
+      if (!service.hash) throw new Error('invalid hash')
+      return service.hash
+    } catch (e) {
+      if (!IsAlreadyExistsError.match(e)) throw e
+      this.warn('service already created')
+      return new IsAlreadyExistsError(e).hash
+    }
+  }
+
+  async startService(serviceHash: string, env: string[]): Promise<string> {
+    try {
+      const instance = await this.api.instance.create({
+        serviceHash,
+        env
+      })
+      if (!instance.hash) throw new Error('invalid hash')
+      return instance.hash
+    } catch (e) {
+      if (!IsAlreadyExistsError.match(e)) throw e
+      this.warn('service already started')
+      return new IsAlreadyExistsError(e).hash
+    }
   }
 }

--- a/src/commands/service/dev.ts
+++ b/src/commands/service/dev.ts
@@ -25,6 +25,9 @@ export default class ServiceDev extends Command {
     default: './'
   }]
 
+  serviceCreated = false
+  instanceCreated = false
+
   async run() {
     const {args, flags} = this.parse(ServiceDev)
 
@@ -35,8 +38,8 @@ export default class ServiceDev extends Command {
 
     process.once('SIGINT', async () => {
       stream.destroy()
-      await ServiceStop.run([instanceHash])
-      await ServiceDelete.run([serviceHash, '--confirm'])
+      if (this.instanceCreated) await ServiceStop.run([instanceHash])
+      if (this.serviceCreated) await ServiceDelete.run([serviceHash, '--confirm'])
     })
   }
 
@@ -44,6 +47,7 @@ export default class ServiceDev extends Command {
     try {
       const service = await this.api.service.create(definition)
       if (!service.hash) throw new Error('invalid hash')
+      this.serviceCreated = true
       return service.hash
     } catch (e) {
       if (!IsAlreadyExistsError.match(e)) throw e
@@ -59,6 +63,7 @@ export default class ServiceDev extends Command {
         env
       })
       if (!instance.hash) throw new Error('invalid hash')
+      this.instanceCreated = true
       return instance.hash
     } catch (e) {
       if (!IsAlreadyExistsError.match(e)) throw e

--- a/src/commands/workflow/compile.ts
+++ b/src/commands/workflow/compile.ts
@@ -1,4 +1,4 @@
-import {flags} from '@oclif/command';
+import {flags} from '@oclif/command'
 import {existsSync, readFileSync} from 'fs'
 import {dirname, join} from 'path'
 


### PR DESCRIPTION
Add better error management for the `service:dev` command.

If a service already exists in database the command will not stop and use the current service. The same for the instance.

If an instance or service was already created, the dev command will not delete it when stopped. This avoids trying to use the dev command to see the logs on service in production and stop the dev and delete the service by mistake.