### PR TITLE
Encode and decode Hashes from and to base58

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -611,6 +611,15 @@
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-0.7.0.tgz",
       "integrity": "sha512-ONhaKPIufzzrlNbqtWFFd+jlnemX6lJAgq9ZeiZtS7I1PIf/la7CW4m83rTXRnVnsMbW2k56pGYu7AUFJD9Pow=="
     },
+    "@types/bytebuffer": {
+      "version": "5.0.40",
+      "resolved": "https://registry.npmjs.org/@types/bytebuffer/-/bytebuffer-5.0.40.tgz",
+      "integrity": "sha512-h48dyzZrPMz25K6Q4+NCwWaxwXany2FhQg/ErOcdZS1ZpsaDnDMZg8JYLMTGz7uvXKrcKGJUZJlZObyfgdaN9g==",
+      "requires": {
+        "@types/long": "*",
+        "@types/node": "*"
+      }
+    },
     "@types/chai": {
       "version": "4.1.7",
       "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.1.7.tgz",
@@ -2731,10 +2740,11 @@
       "dev": true
     },
     "grpc": {
-      "version": "1.23.1",
-      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.23.1.tgz",
-      "integrity": "sha512-hEhb5aBh5tlGw6vIwdOv3rMCRjJrRDI/RCjcBlWEfog0jI/2Q5Yzt6zNvUxfQHOYMMFXWX4E3u+nm7jr/qoKYw==",
+      "version": "1.23.3",
+      "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.23.3.tgz",
+      "integrity": "sha512-7vdzxPw9s5UYch4aUn4hyM5tMaouaxUUkwkgJlwbR4AXMxiYZJOv19N2ps2eKiuUbJovo5fnGF9hg/X91gWYjw==",
       "requires": {
+        "@types/bytebuffer": "^5.0.40",
         "lodash.camelcase": "^4.3.0",
         "lodash.clone": "^4.5.0",
         "nan": "^2.13.2",
@@ -2775,7 +2785,7 @@
           }
         },
         "chownr": {
-          "version": "1.1.1",
+          "version": "1.1.2",
           "bundled": true
         },
         "code-point-at": {
@@ -2793,6 +2803,13 @@
         "core-util-is": {
           "version": "1.0.2",
           "bundled": true
+        },
+        "debug": {
+          "version": "3.2.6",
+          "bundled": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
         },
         "deep-extend": {
           "version": "0.6.0",
@@ -2831,12 +2848,24 @@
             "wide-align": "^1.1.0"
           }
         },
+        "glob": {
+          "version": "7.1.4",
+          "bundled": true,
+          "requires": {
+            "fs.realpath": "^1.0.0",
+            "inflight": "^1.0.4",
+            "inherits": "2",
+            "minimatch": "^3.0.4",
+            "once": "^1.3.0",
+            "path-is-absolute": "^1.0.0"
+          }
+        },
         "has-unicode": {
           "version": "2.0.1",
           "bundled": true
         },
         "iconv-lite": {
-          "version": "0.4.23",
+          "version": "0.4.24",
           "bundled": true,
           "requires": {
             "safer-buffer": ">= 2.1.2 < 3"
@@ -2858,7 +2887,7 @@
           }
         },
         "inherits": {
-          "version": "2.0.3",
+          "version": "2.0.4",
           "bundled": true
         },
         "ini": {
@@ -2915,6 +2944,10 @@
             }
           }
         },
+        "ms": {
+          "version": "2.1.2",
+          "bundled": true
+        },
         "needle": {
           "version": "2.4.0",
           "bundled": true,
@@ -2922,19 +2955,6 @@
             "debug": "^3.2.6",
             "iconv-lite": "^0.4.4",
             "sax": "^1.2.4"
-          },
-          "dependencies": {
-            "debug": {
-              "version": "3.2.6",
-              "bundled": true,
-              "requires": {
-                "ms": "^2.1.1"
-              }
-            },
-            "ms": {
-              "version": "2.1.2",
-              "bundled": true
-            }
           }
         },
         "node-pre-gyp": {
@@ -2966,7 +2986,7 @@
           "bundled": true
         },
         "npm-packlist": {
-          "version": "1.4.1",
+          "version": "1.4.4",
           "bundled": true,
           "requires": {
             "ignore-walk": "^3.0.1",
@@ -3057,24 +3077,10 @@
           }
         },
         "rimraf": {
-          "version": "2.6.3",
+          "version": "2.7.1",
           "bundled": true,
           "requires": {
             "glob": "^7.1.3"
-          },
-          "dependencies": {
-            "glob": {
-              "version": "7.1.4",
-              "bundled": true,
-              "requires": {
-                "fs.realpath": "^1.0.0",
-                "inflight": "^1.0.4",
-                "inherits": "2",
-                "minimatch": "^3.0.4",
-                "once": "^1.3.0",
-                "path-is-absolute": "^1.0.0"
-              }
-            }
           }
         },
         "safe-buffer": {
@@ -3090,7 +3096,7 @@
           "bundled": true
         },
         "semver": {
-          "version": "5.7.0",
+          "version": "5.7.1",
           "bundled": true
         },
         "set-blocking": {
@@ -3098,7 +3104,7 @@
           "bundled": true
         },
         "signal-exit": {
-          "version": "3.0.1",
+          "version": "3.0.2",
           "bundled": true
         },
         "string-width": {
@@ -4332,15 +4338,26 @@
       "dev": true
     },
     "mesg-js": {
-      "version": "4.3.0-beta",
-      "resolved": "https://registry.npmjs.org/mesg-js/-/mesg-js-4.3.0-beta.tgz",
-      "integrity": "sha512-nFUSINLEeN/L+N+5eaL/XcXEE/HRiq/boG9JVj3Eg5WCB9xyATa4xEuC9FGqaEqQfya+udE9MbxXygcAy/wzhg==",
+      "version": "4.3.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mesg-js/-/mesg-js-4.3.0-beta.1.tgz",
+      "integrity": "sha512-0E42wR8fbOpCdgWlilnkzj+Dt9i8AWobjUJFsZCPgzIC3smjdvNAJEJfmU7VvaVpow7A0JwW4hGnhDxk3LZxHw==",
       "requires": {
         "@grpc/proto-loader": "^0.5.1",
+        "base-x": "^3.0.6",
         "grpc": "^1.21.1",
         "js-yaml": "^3.13.1",
         "pb-util": "^0.1.1",
         "uuid": "^3.3.2"
+      },
+      "dependencies": {
+        "base-x": {
+          "version": "3.0.6",
+          "resolved": "https://registry.npmjs.org/base-x/-/base-x-3.0.6.tgz",
+          "integrity": "sha512-4PaF8u2+AlViJxRVjurkLTxpp7CaFRD/jo5rPT9ONnKxyhQ8f59yzamEvq7EkriG56yn5On4ONyaG75HLqr46w==",
+          "requires": {
+            "safe-buffer": "^5.0.1"
+          }
+        }
       }
     },
     "micromatch": {

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "is-git-url": "^1.0.0",
     "js-yaml": "^3.13.1",
     "lodash.pick": "^4.4.0",
-    "mesg-js": "^4.3.0-beta",
+    "mesg-js": "^4.3.0-beta.1",
     "node-docker-api": "^1.1.22",
     "rimraf": "^2.6.3",
     "tar": "^4.4.8",

--- a/src/commands/service/create.ts
+++ b/src/commands/service/create.ts
@@ -1,5 +1,6 @@
 import {flags} from '@oclif/command'
 import {ServiceCreateOutputs} from 'mesg-js/lib/api'
+import * as base58 from 'mesg-js/lib/util/base58'
 
 import Command from '../../root-command'
 
@@ -27,10 +28,10 @@ export default class ServiceCreate extends Command {
     this.spinner.start('Create service')
     const resp = await this.api.service.create(JSON.parse(args.DEFINITION))
     if (!resp.hash) { throw new Error('invalid response') }
-    this.spinner.stop(resp.hash)
+    this.spinner.stop(base58.encode(resp.hash))
     if (flags.start) {
       this.spinner.start('Starting service')
-      const start = await ServiceStart.run([resp.hash])
+      const start = await ServiceStart.run([base58.encode(resp.hash)])
       this.spinner.stop(start.hash)
     }
     return resp

--- a/src/commands/service/delete.ts
+++ b/src/commands/service/delete.ts
@@ -1,5 +1,6 @@
 import {flags} from '@oclif/command'
 import cli from 'cli-ux'
+import * as base58 from 'mesg-js/lib/util/base58'
 
 import Command from '../../root-command'
 import serviceResolver from '../../utils/service-resolver'
@@ -25,7 +26,7 @@ export default class ServiceDelete extends Command {
     this.spinner.start('Deleting service(s)')
     for (const hash of argv) {
       const serviceHash = await serviceResolver(this.api, hash)
-      this.spinner.status = serviceHash
+      this.spinner.status = base58.encode(serviceHash)
       await this.api.service.delete({hash: serviceHash})
     }
     this.spinner.stop()

--- a/src/commands/service/execute.ts
+++ b/src/commands/service/execute.ts
@@ -1,6 +1,7 @@
 import {flags} from '@oclif/command'
 import {readFileSync} from 'fs'
 import {ExecutionCreateOutputs} from 'mesg-js/lib/api'
+import * as base58 from 'mesg-js/lib/util/base58'
 
 import Command from '../../root-command'
 import instanceResolver from '../../utils/instance-resolver'
@@ -39,7 +40,7 @@ export default class ServiceExecute extends Command {
       hash: instanceHash
     })
     if (!instance.serviceHash) { throw new Error('invalid service hash') }
-    const service = await ServiceDetail.run([instance.serviceHash, '--silent'])
+    const service = await ServiceDetail.run([base58.encode(instance.serviceHash), '--silent'])
 
     const task = service.tasks.find((x: any) => x.key === args.TASK)
     if (!task) {

--- a/src/commands/service/list.ts
+++ b/src/commands/service/list.ts
@@ -1,5 +1,6 @@
 import cli from 'cli-ux'
 import {Instance, Service} from 'mesg-js/lib/api/types'
+import * as base58 from 'mesg-js/lib/util/base58'
 
 import Command from '../../root-command'
 
@@ -17,13 +18,13 @@ export default class ServiceList extends Command {
     const {instances} = await this.api.instance.list({})
     if (!services) return []
     cli.table<Service>(services, {
-      hash: {header: 'HASH', get: x => x.hash},
+      hash: {header: 'HASH', get: x => x.hash ? base58.encode(x.hash) : ''},
       sid: {header: 'SID', get: x => x.sid},
       instances: {
         header: 'INSTANCES',
         get: x => ((instances || []) as Instance[])
-          .filter(y => y.serviceHash === x.hash)
-          .map(y => y.hash)
+          .filter(y => y.serviceHash && x.hash && y.serviceHash.toString() === x.hash.toString())
+          .map(y => y.hash && base58.encode(y.hash))
           .join('\n')
       }
     }, {printLine: this.log, ...flags})

--- a/src/commands/service/start.ts
+++ b/src/commands/service/start.ts
@@ -1,5 +1,6 @@
 import {flags} from '@oclif/command'
 import {InstanceCreateOutputs} from 'mesg-js/lib/api'
+import * as base58 from 'mesg-js/lib/util/base58'
 
 import Command from '../../root-command'
 import serviceResolver from '../../utils/service-resolver'
@@ -30,7 +31,7 @@ export default class ServiceStart extends Command {
       env: flags.env
     })
     if (!instance.hash) throw new Error('invalid instance')
-    this.spinner.stop(instance.hash)
+    this.spinner.stop(base58.encode(instance.hash))
     return instance
   }
 }

--- a/src/commands/workflow/create.ts
+++ b/src/commands/workflow/create.ts
@@ -1,4 +1,5 @@
 import {WorkflowCreateOutputs} from 'mesg-js/lib/api'
+import * as base58 from 'mesg-js/lib/util/base58'
 
 import Command from '../../root-command'
 
@@ -20,7 +21,7 @@ export default class WorkflowCreate extends Command {
     this.spinner.start('Create workflow')
     const resp = await this.api.workflow.create(JSON.parse(args.DEFINITION))
     if (!resp.hash) { throw new Error('invalid response') }
-    this.spinner.stop(resp.hash)
+    this.spinner.stop(base58.encode(resp.hash))
     return resp
   }
 }

--- a/src/commands/workflow/delete.ts
+++ b/src/commands/workflow/delete.ts
@@ -1,5 +1,6 @@
 import {flags} from '@oclif/command'
 import cli from 'cli-ux'
+import * as base58 from 'mesg-js/lib/util/base58'
 
 import Command from '../../root-command'
 
@@ -24,7 +25,7 @@ export default class WorkflowDelete extends Command {
     this.spinner.start('Deleting workflow(s)')
     for (const hash of argv) {
       this.spinner.status = hash
-      await this.api.workflow.delete({hash})
+      await this.api.workflow.delete({hash: base58.decode(hash)})
     }
     this.spinner.stop()
     return argv

--- a/src/root-command.ts
+++ b/src/root-command.ts
@@ -5,6 +5,7 @@ import {application} from 'mesg-js'
 import createApi, {API, InfoOutputs} from 'mesg-js/lib/api'
 import {hash} from 'mesg-js/lib/api/types'
 import {Application} from 'mesg-js/lib/application'
+import * as base58 from 'mesg-js/lib/util/base58'
 import {format, inspect} from 'util'
 
 export default abstract class extends Command {
@@ -57,7 +58,12 @@ export default abstract class extends Command {
   styledJSON(data: any) {
     const {flags} = this.parse()
     if (flags.silent) return
-    cli.styledJSON(data)
+    const base58EncodedHash = JSON.parse(JSON.stringify(data, (key: string, value: any): any => {
+      return key && RegExp('hash', 'i').test(key) && value && value.type === 'Buffer'
+        ? base58.encode(value.data)
+        : value
+    }))
+    cli.styledJSON(base58EncodedHash)
   }
 
   async catch(err: Error) {

--- a/src/root-command.ts
+++ b/src/root-command.ts
@@ -3,6 +3,7 @@ import {IConfig} from '@oclif/config'
 import {cli} from 'cli-ux'
 import {application} from 'mesg-js'
 import createApi, {API, InfoOutputs} from 'mesg-js/lib/api'
+import {hash} from 'mesg-js/lib/api/types'
 import {Application} from 'mesg-js/lib/application'
 import {format, inspect} from 'util'
 
@@ -71,7 +72,7 @@ export default abstract class extends Command {
     }
   }
 
-  async execute(request: {instanceHash: string, taskKey: string, inputs?: {[key: string]: any}, tags?: string[]}): Promise<{[key: string]: any}> {
+  async execute(request: {instanceHash: hash, taskKey: string, inputs?: {[key: string]: any}, tags?: string[]}): Promise<{[key: string]: any}> {
     const exec = await this._app.executeTaskAndWaitResult({
       instanceHash: request.instanceHash,
       tags: request.tags || [],
@@ -87,7 +88,7 @@ export default abstract class extends Command {
     return this.api.core.info()
   }
 
-  async engineServiceInstance(key: string) {
+  async engineServiceInstance(key: string): Promise<hash> {
     const info = await this.info()
     const service = info.services.find((x: any) => x.key === key)
     if (!service) {

--- a/src/root-command.ts
+++ b/src/root-command.ts
@@ -59,7 +59,7 @@ export default abstract class extends Command {
     const {flags} = this.parse()
     if (flags.silent) return
     const base58EncodedHash = JSON.parse(JSON.stringify(data, (key: string, value: any): any => {
-      return key && RegExp('hash', 'i').test(key) && value && value.type === 'Buffer'
+      return key && RegExp('hash$', 'i').test(key) && value && value.type === 'Buffer'
         ? base58.encode(value.data)
         : value
     }))

--- a/src/utils/compiler.ts
+++ b/src/utils/compiler.ts
@@ -1,7 +1,7 @@
 import yaml from 'js-yaml'
 import pick from 'lodash.pick'
 import * as WorkflowType from 'mesg-js/lib/api/typedef/workflow'
-import {Service, Workflow} from 'mesg-js/lib/api/types'
+import {Service, Workflow, hash} from 'mesg-js/lib/api/types'
 
 const decode = (content: Buffer) => yaml.safeLoad(content.toString())
 
@@ -32,7 +32,7 @@ export const service = async (content: Buffer): Promise<Service> => {
   }
 }
 
-export const workflow = async (content: Buffer, instanceResolver: (object: any) => Promise<string>): Promise<Workflow> => {
+export const workflow = async (content: Buffer, instanceResolver: (object: any) => Promise<hash>): Promise<Workflow> => {
   const definition = decode(content)
   const createNode = async (def: any, index: number): Promise<WorkflowType.types.Workflow.INode> => ({
     key: def.key || `node-${index}`,

--- a/src/utils/error.ts
+++ b/src/utils/error.ts
@@ -1,3 +1,6 @@
+import {hash} from 'mesg-js/lib/api/types'
+import * as base58 from 'mesg-js/lib/util/base58'
+
 export class IsAlreadyExistsError extends Error {
   static ID = 'ALREADY_EXISTS'
   static regexp = new RegExp('\"(.*)\" already exists')
@@ -5,13 +8,13 @@ export class IsAlreadyExistsError extends Error {
     return IsAlreadyExistsError.regexp.test(err.message)
   }
 
-  hash: string
+  hash: hash
 
   constructor(error: Error) {
     super(error.message)
     const res = IsAlreadyExistsError.regexp.exec(error.message)
     const hash = res && res.length >= 1 ? res[1] : ''
-    this.hash = hash
+    this.hash = base58.decode(hash)
     this.name = IsAlreadyExistsError.ID
   }
 }

--- a/src/utils/instance-resolver.ts
+++ b/src/utils/instance-resolver.ts
@@ -1,11 +1,21 @@
 import {API, hash} from 'mesg-js/lib/api/types'
+import * as base58 from 'mesg-js/lib/util/base58'
 import {resolveSID} from 'mesg-js/lib/util/resolve'
 
 export default async (api: API, sidOrHash: hash | string): Promise<hash> => {
   try {
-    await api.instance.get({hash: sidOrHash})
-    return sidOrHash
-  } catch {
-    return resolveSID(api, sidOrHash)
+    let hash: hash
+    if (sidOrHash instanceof Uint8Array) {
+      hash = sidOrHash
+    } else {
+      hash = base58.decode(sidOrHash)
+    }
+    await api.instance.get({hash})
+    return hash
+  } catch (err) {
+    if (typeof sidOrHash === 'string') {
+      return resolveSID(api, sidOrHash)
+    }
+    throw err
   }
 }

--- a/src/utils/service-resolver.ts
+++ b/src/utils/service-resolver.ts
@@ -1,9 +1,16 @@
 import {API, hash} from 'mesg-js/lib/api/types'
+import * as base58 from 'mesg-js/lib/util/base58'
 
 export default async (api: API, sidOrHash: hash | string): Promise<hash> => {
   try {
-    await api.service.get({hash: sidOrHash})
-    return sidOrHash
+    let hash: hash
+    if (sidOrHash instanceof Uint8Array) {
+      hash = sidOrHash
+    } else {
+      hash = base58.decode(sidOrHash)
+    }
+    await api.service.get({hash})
+    return hash
   } catch {
     const {services} = await api.service.list({})
     const match = (services || []).filter(x => x.sid === sidOrHash)


### PR DESCRIPTION
Fix https://github.com/mesg-foundation/cli/issues/137

Related to https://github.com/mesg-foundation/mesg-js/issues/123 and https://github.com/mesg-foundation/engine/issues/1265.

Because of mesg-foundation/engine#1270, hashes are now in bytes instead of string over the gRPC API.

This PR update the CLI to use mesg-js version of https://github.com/mesg-foundation/mesg-js/pull/124 and encode / decode the hash properly.