### PR TITLE
Force a configuration to be set for services

### DIFF
--- a/src/utils/compiler.ts
+++ b/src/utils/compiler.ts
@@ -18,7 +18,8 @@ const parseParams = (params: any): any => mapToArray(params).map(x => ({
 export const service = async (content: Buffer): Promise<Service> => {
   const definition = decode(content)
   return {
-    ...pick(definition, ['sid', 'name', 'description', 'configuration', 'repository']),
+    ...pick(definition, ['sid', 'name', 'description', 'repository']),
+    configuration: definition.configuration || {},
     dependencies: mapToArray(definition.dependencies),
     tasks: mapToArray(definition.tasks).map(x => ({
       ...pick(x, ['key', 'name', 'description']),


### PR DESCRIPTION
When a service is sent to the API without any configuration, the API crashes with a segmentation fault. This ensures that we always call the API with all the parameter needed.

Probably related to https://github.com/mesg-foundation/engine/issues/1275