### PR TITLE
add env support for processes

### DIFF
--- a/src/commands/process/compile.ts
+++ b/src/commands/process/compile.ts
@@ -46,7 +46,7 @@ export default class ProcessCompile extends Command {
         return this.sourceToInstance(args.PROCESS_FILE, src, env)
       }
       throw new Error('at least one of the following parameter should be set: "instanceHash", "service" or "src"')
-    }, flags.env.reduce((prev, env) => ({
+    }, (flags.env || []).reduce((prev, env) => ({
       ...prev,
       [env.split('=')[0]]: env.split('=')[1],
     }), {}))

--- a/src/commands/process/compile.ts
+++ b/src/commands/process/compile.ts
@@ -13,7 +13,12 @@ export default class ProcessCompile extends Command {
 
   static flags = {
     ...Command.flags,
-    dev: flags.boolean({description: 'compile the process and automatically deploy and start all the services'})
+    dev: flags.boolean({description: 'compile the process and automatically deploy and start all the services'}),
+    env: flags.string({
+      description: 'Set environment variables',
+      multiple: true,
+      helpValue: 'FOO=BAR'
+    })
   }
 
   static args = [{
@@ -41,7 +46,10 @@ export default class ProcessCompile extends Command {
         return this.sourceToInstance(args.PROCESS_FILE, src, env)
       }
       throw new Error('at least one of the following parameter should be set: "instanceHash", "service" or "src"')
-    })
+    }, flags.env.reduce((prev, env) => ({
+      ...prev,
+      [env.split('=')[0]]: env.split('=')[1],
+    }), {}))
     this.styledJSON(definition)
     this.spinner.stop()
     return definition

--- a/src/utils/compiler.ts
+++ b/src/utils/compiler.ts
@@ -6,7 +6,12 @@ import {hash, Process, Service} from 'mesg-js/lib/api/types'
 const replaceVariable = (value: any, env: { [key: string]: string }) => {
   if (typeof value !== 'string') return value
   const reg = new RegExp('\\$\\(env\\:(.*)\\)', 'g')
-  return value.replace(reg, (match: string, p1: string) => env[p1])
+  return value.replace(reg, (match: string, p1: string) => {
+    if (!Object.keys(env).includes(p1)) {
+      throw new Error('env variable ' + p1 + ' must be set')
+    }
+    return env[p1]
+  })
 }
 
 const decode = (content: Buffer, env: { [key: string]: string }) => {

--- a/src/utils/compiler.ts
+++ b/src/utils/compiler.ts
@@ -3,7 +3,18 @@ import pick from 'lodash.pick'
 import * as ProcessType from 'mesg-js/lib/api/typedef/process'
 import {hash, Process, Service} from 'mesg-js/lib/api/types'
 
-const decode = (content: Buffer) => yaml.safeLoad(content.toString())
+const replaceVariable = (value: any, env: { [key: string]: string }) => {
+  if (typeof value !== 'string') return value
+  const reg = new RegExp('\\$\\(env\\:(.*)\\)', 'g')
+  return value.replace(reg, (match: string, p1: string) => env[p1])
+}
+
+const decode = (content: Buffer, env: { [key: string]: string }) => {
+  const data = yaml.safeLoad(content.toString())
+  return JSON.parse(JSON.stringify(data), function (this: any, key: string, value: any) {
+    return replaceVariable(value, env)
+  })
+}
 
 const mapToArray = (inputs: any) => Object.keys(inputs || {}).map(key => ({
   ...inputs[key],
@@ -16,7 +27,7 @@ const parseParams = (params: any): any => mapToArray(params).map(x => ({
 }))
 
 export const service = async (content: Buffer): Promise<Service> => {
-  const definition = decode(content)
+  const definition = decode(content, {})
   return {
     ...pick(definition, ['sid', 'name', 'description', 'repository']),
     configuration: definition.configuration || {},
@@ -83,8 +94,8 @@ const nodeCompiler = async (
   }
 }
 
-export const process = async (content: Buffer, instanceResolver: (object: any) => Promise<hash>): Promise<Process> => {
-  const definition = decode(content)
+export const process = async (content: Buffer, instanceResolver: (object: any) => Promise<hash>, envs: { [key: string]: string }): Promise<Process> => {
+  const definition = decode(content, envs)
 
   let nodes = []
   let edges = []


### PR DESCRIPTION
fix https://github.com/mesg-foundation/cli/issues/133

Support env injection on the process to be able to replace value when compiling the process.

You can now add in any value of the yaml the following:

```yml
$(env:XXX)
```

where `XXX` is the name of your env variable and when compiling the process you can use

```
mesg-cli process:compile --env XXX=hello
```