### PR TITLE
Add support for constants

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4338,9 +4338,8 @@
       "dev": true
     },
     "mesg-js": {
-      "version": "4.3.1",
-      "resolved": "https://registry.npmjs.org/mesg-js/-/mesg-js-4.3.1.tgz",
-      "integrity": "sha512-PgelJm19SKAe5BbPujIFxfJ+/yr5YwyFh7zEzJkFNunTiSN1qOvKbxAgtLvi9KJqBvo51rKjflXjv0NCYrx02A==",
+      "version": "github:mesg-foundation/mesg-js#2ea8682f0374232bba63893bcaed93ba5a46ada2",
+      "from": "github:mesg-foundation/mesg-js#build/add-mapping-constant-support",
       "requires": {
         "@grpc/proto-loader": "^0.5.1",
         "base-x": "^3.0.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -4338,8 +4338,9 @@
       "dev": true
     },
     "mesg-js": {
-      "version": "github:mesg-foundation/mesg-js#2ea8682f0374232bba63893bcaed93ba5a46ada2",
-      "from": "github:mesg-foundation/mesg-js#build/add-mapping-constant-support",
+      "version": "4.4.0-beta.1",
+      "resolved": "https://registry.npmjs.org/mesg-js/-/mesg-js-4.4.0-beta.1.tgz",
+      "integrity": "sha512-FmyunfuTbZTdXcLx50SQP0g5MljC5JgxZvbeRbiptPMKlJzar+RI/hMG/BeqaPQLIY0rO94KkniNqfo23WxQTA==",
       "requires": {
         "@grpc/proto-loader": "^0.5.1",
         "base-x": "^3.0.6",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "is-git-url": "^1.0.0",
     "js-yaml": "^3.13.1",
     "lodash.pick": "^4.4.0",
-    "mesg-js": "github:mesg-foundation/mesg-js#build/add-mapping-constant-support",
+    "mesg-js": "^4.4.0-beta.1",
     "node-docker-api": "^1.1.22",
     "rimraf": "^2.6.3",
     "tar": "^4.4.8",

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "is-git-url": "^1.0.0",
     "js-yaml": "^3.13.1",
     "lodash.pick": "^4.4.0",
-    "mesg-js": "^4.3.1",
+    "mesg-js": "github:mesg-foundation/mesg-js#build/add-mapping-constant-support",
     "node-docker-api": "^1.1.22",
     "rimraf": "^2.6.3",
     "tar": "^4.4.8",

--- a/src/utils/compiler.ts
+++ b/src/utils/compiler.ts
@@ -2,6 +2,7 @@ import yaml from 'js-yaml'
 import pick from 'lodash.pick'
 import * as ProcessType from 'mesg-js/lib/api/typedef/process'
 import {hash, Process, Service} from 'mesg-js/lib/api/types'
+import {encodeField} from 'mesg-js/lib/util/encoder'
 
 const replaceVariable = (value: any, env: { [key: string]: string }) => {
   if (typeof value !== 'string') return value
@@ -79,10 +80,16 @@ const nodeCompiler = async (
       key,
       outputs: Object.keys(def).map(key => ({
         key,
-        ref: {
-          key: def[key].key,
-          nodeKey: def[key].stepKey || opts.defaultNodeKey,
-        }
+        ...(typeof def[key] === 'object' && def[key].key  // if the value is an object containing an attribute key
+          ? {
+            ref: {
+              key: def[key].key,
+              nodeKey: def[key].stepKey || opts.defaultNodeKey,
+            }
+          }
+          : {
+            constant: encodeField(def[key])
+          })
       }))
     }),
     filter: async (def: any, key: string, opts: any): Promise<ProcessType.types.Process.Node.IFilter> => ({


### PR DESCRIPTION
dependency: https://github.com/mesg-foundation/mesg-js/pull/132

Add compilation of constants for processes.

If the mapping contains an object with an attribute key then it is considered as a reference otherwise it is a constant