### PR TITLE
Add process log command

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ USAGE
 * [`mesg-cli process:delete PROCESS_HASH...`](#mesg-cli-processdelete-process_hash)
 * [`mesg-cli process:detail PROCESS_HASH`](#mesg-cli-processdetail-process_hash)
 * [`mesg-cli process:list`](#mesg-cli-processlist)
+* [`mesg-cli process:logs PROCESS_HASH`](#mesg-cli-processlogs-process_hash)
 * [`mesg-cli service:compile [SERVICE]`](#mesg-cli-servicecompile-service)
 * [`mesg-cli service:create DEFINITION`](#mesg-cli-servicecreate-definition)
 * [`mesg-cli service:delete SERVICE_HASH...`](#mesg-cli-servicedelete-service_hash)
@@ -447,6 +448,23 @@ OPTIONS
 ```
 
 _See code: [src/commands/process/list.ts](https://github.com/mesg-foundation/cli/blob/v1.3.2/src/commands/process/list.ts)_
+
+## `mesg-cli process:logs PROCESS_HASH`
+
+Log the executions related to a process
+
+```
+USAGE
+  $ mesg-cli process:logs PROCESS_HASH
+
+OPTIONS
+  -h, --help       show CLI help
+  -p, --port=port  [default: 50052] Port to access the MESG engine
+  -q, --quiet      Display only essential information
+  --host=host      [default: localhost] Host to access the MESG engine
+```
+
+_See code: [src/commands/process/logs.ts](https://github.com/mesg-foundation/cli/blob/v1.3.1/src/commands/process/logs.ts)_
 
 ## `mesg-cli service:compile [SERVICE]`
 

--- a/src/commands/process/logs.ts
+++ b/src/commands/process/logs.ts
@@ -1,0 +1,94 @@
+import chalk from 'chalk'
+import {Execution, ExecutionStatus, Service} from 'mesg-js/lib/api'
+import * as b58 from 'mesg-js/lib/util/base58'
+import {decode} from 'mesg-js/lib/util/encoder'
+import {inspect} from 'util'
+
+import Command from '../../root-command'
+
+export default class ProcessLogs extends Command {
+  static description = 'Log the executions related to a process'
+
+  static flags = {
+    ...Command.flags,
+  }
+
+  static args = [{
+    name: 'PROCESS_HASH',
+    required: true,
+  }]
+
+  services: {[key: string]: Service} = {}
+
+  async run() {
+    const {args} = this.parse(ProcessLogs)
+
+    const process = await this.api.process.get({
+      hash: b58.decode(args.PROCESS_HASH)
+    })
+    if (!process.hash) {
+      throw new Error('invalid process hash')
+    }
+    if (process.nodes) {
+      const instanceHashes = process.nodes
+        .map(({event, result, task}) => {
+          if (event) return event.instanceHash
+          if (result) return result.instanceHash
+          if (task) return task.instanceHash
+        })
+        .filter(x => x && x.length > 0)
+      for (const hash of instanceHashes) {
+        if (!hash) continue
+        const instance = await this.api.instance.get({hash})
+        const service = await this.api.service.get({hash: instance.serviceHash})
+        this.services[b58.encode(hash)] = service
+      }
+    }
+
+    const streams: (() => any)[] = []
+    const results = this.api.execution.stream({
+      filter: {
+        statuses: [
+          ExecutionStatus.COMPLETED,
+          ExecutionStatus.FAILED,
+        ],
+      }
+    })
+    streams.push(() => results.cancel())
+    results
+      .on('data', this.handlerResult(process.hash))
+      .on('error', (error: Error) => { this.warn('Result stream error: ' + error.message) })
+
+    return {
+      destroy: () => {
+        streams.forEach(s => s())
+      }
+    }
+  }
+
+  handlerResult(processHash: Uint8Array) {
+    return (execution: Execution) => {
+      if (!execution.processHash) return
+      if (b58.encode(execution.processHash) !== b58.encode(processHash)) return
+      this.log(this.formatResult(execution))
+    }
+  }
+
+  formatResult(execution: Execution) {
+    if (!execution.instanceHash) return
+    const prefix = [
+      `[${execution.stepID}]`,
+      b58.encode(execution.instanceHash),
+      this.services[b58.encode(execution.instanceHash)].sid,
+      execution.taskKey,
+    ].join(' - ')
+    if (execution.error) {
+      return `${prefix}: ` + chalk.red('ERROR:', execution.error)
+    }
+    if (!execution.outputs) return
+    return prefix +
+      '\n\tinputs:  ' + chalk.gray(inspect(decode(execution.inputs || {}))) +
+      '\n\toutputs: ' + chalk.gray(inspect(decode(execution.outputs || {}))) +
+      '\n'
+  }
+}


### PR DESCRIPTION
Add the command `process:log` in order to display all the executions that match a specific process and display useful information

Here is an example of a process log

```
[execute-task-x] - H74Qqq8nT5JZ9GSJmuSWLN5benWZPkUb5pYcvQLsoZX - serviceA - taskX
        inputs:  { message: 'event' }
        outputs: { value: 'serviceA#taskX' }

[toTaskY] - DTjy36ApV5YVbyXm67iWeAsD9uCbZETcPL1TbUPwHeYJ - serviceB - taskY
        inputs:  { inputA: 'serviceA#taskX' }
        outputs: { res: 'serviceA#taskX => serviceB#taskY' }
```

What do you think about this log? Any idea of how to improve it?