### PR TITLE
Add new account-exp commands

### DIFF
--- a/src/account-command.ts
+++ b/src/account-command.ts
@@ -3,6 +3,7 @@ import {cli} from 'cli-ux'
 
 import Command from './root-command'
 
+// TODO: to delete when ethwallet is not used.
 export abstract class WithoutPassphrase extends Command {
   static flags = {
     ...Command.flags
@@ -11,6 +12,7 @@ export abstract class WithoutPassphrase extends Command {
   static SERVICE_NAME = 'EthWallet'
 }
 
+// TODO: to delete when ethwallet is not used.
 export abstract class WithPassphrase extends WithoutPassphrase {
   static flags = {
     ...WithoutPassphrase.flags,

--- a/src/commands/exp/account/create.ts
+++ b/src/commands/exp/account/create.ts
@@ -1,0 +1,29 @@
+import {WithCredential as Command} from '../../../credential-command'
+
+export default class AccountExpCreate extends Command {
+  static description = 'Create an account'
+  static hidden = true
+
+  static flags = {
+    ...Command.flags,
+  }
+
+  static args = [{
+    name: 'ACCOUNT_NAME',
+    required: true
+  }]
+
+  async run() {
+    const {args} = this.parse(AccountExpCreate)
+    const passphrase = await this.getCredentialPassphrase()
+    this.spinner.start('Creating account')
+    const account = await this.api.account.create({
+      name: args.ACCOUNT_NAME,
+      password: passphrase,
+    })
+    this.spinner.stop(account.address || '')
+    this.warn('Make sure to backup the mnemonic:')
+    this.log(account.mnemonic || '')
+    return account
+  }
+}

--- a/src/commands/exp/account/delete.ts
+++ b/src/commands/exp/account/delete.ts
@@ -1,0 +1,27 @@
+import {WithCredential as Command} from '../../../credential-command'
+
+export default class AccountExpDelete extends Command {
+  static description = 'Delete an account'
+  static hidden = true
+
+  static flags = {
+    ...Command.flags,
+  }
+
+  static args = [{
+    name: 'ACCOUNT_NAME',
+    required: true
+  }]
+
+  async run() {
+    const {args} = this.parse(AccountExpDelete)
+    const passphrase = await this.getCredentialPassphrase()
+    this.spinner.start('Deleting account')
+    const data = await this.api.account.delete({}, {
+      username: args.ACCOUNT_NAME,
+      passphrase: passphrase || '',
+    })
+    this.spinner.stop()
+    return data
+  }
+}

--- a/src/commands/exp/account/list.ts
+++ b/src/commands/exp/account/list.ts
@@ -1,0 +1,24 @@
+import {cli} from 'cli-ux'
+
+import {WithoutPassphrase as Command} from '../../../account-command'
+
+export default class AccountExpList extends Command {
+  static description = 'List accounts'
+  static hidden = true
+
+  static flags = {
+    ...Command.flags,
+    ...cli.table.flags()
+  }
+
+  async run() {
+    const {flags} = this.parse(AccountExpList)
+
+    const {accounts} = await this.api.account.list({})
+    cli.table(accounts, {
+      name: {header: 'NAME', get: x => x.name},
+      address: {header: 'ADDRESS', get: x => x.address},
+    }, {printLine: this.log, ...flags})
+    return accounts
+  }
+}

--- a/src/credential-command.ts
+++ b/src/credential-command.ts
@@ -1,0 +1,36 @@
+import {flags} from '@oclif/command'
+import {cli} from 'cli-ux'
+import {Credential} from 'mesg-js/lib/api'
+
+import Command from './root-command'
+
+export abstract class WithCredential extends Command {
+  static flags = {
+    ...Command.flags,
+    account: flags.string({
+      description: 'Name of the account'
+    }),
+    passphrase: flags.string({
+      description: 'Passphrase of the account'
+    })
+  }
+
+  async getCredential(): Promise<Credential> {
+    return {
+      username: await this.getCredentialUsername(),
+      passphrase: await this.getCredentialPassphrase(),
+    }
+  }
+
+  async getCredentialUsername(): Promise<string> {
+    const {flags} = this.parse()
+    if (flags.account) return flags.account
+    return cli.prompt('Type the name of the account', {type: 'hide'})
+  }
+
+  async getCredentialPassphrase(): Promise<string> {
+    const {flags} = this.parse()
+    if (flags.passphrase) return flags.passphrase
+    return cli.prompt('Type the passphrase', {type: 'hide'})
+  }
+}


### PR DESCRIPTION
Here is the PR for the implementation of account API.

I created new commands to still access the previous ones. The commands are:
```
exp:account:create
exp:account:delete
exp:account:list
```

Need to manually install mesg-js from PR https://github.com/mesg-foundation/mesg-js/pull/134 to use `account:delete` and engine PR https://github.com/mesg-foundation/engine/pull/1355

Related with https://github.com/mesg-foundation/engine/pull/1314
Closes https://github.com/mesg-foundation/cli/issues/168