### PR TITLE
Make deployment from remote deterministic

### DIFF
--- a/src/utils/deployer.ts
+++ b/src/utils/deployer.ts
@@ -80,7 +80,8 @@ export const createTar = (path: string): Readable => {
     strict: true,
     gzip: true,
     portable: true,
-  }, readdirSync(path))
+    noMtime: true,
+  } as any, readdirSync(path))
     .on('error', (error: Error) => {
       throw error
     })


### PR DESCRIPTION
fix https://github.com/mesg-foundation/cli/issues/7

The fix the issue when fetching the same service from a github repository the service created had different hashes.

By removing the Mtime we actually create a consistent hash for the services