### PR TITLE
Add key to process:list

### DIFF
--- a/src/commands/process/list.ts
+++ b/src/commands/process/list.ts
@@ -18,6 +18,7 @@ export default class ProcessList extends Command {
     if (!processes) return []
     cli.table<Process>(processes, {
       hash: {header: 'HASH', get: x => x.hash ? base58.encode(x.hash) : ''},
+      key: {header: 'KEY', get: x => x.key},
     }, {printLine: this.log, ...flags})
     return processes
   }


### PR DESCRIPTION
The command `process:list` was only displaying the hash when every process has a required `key`.

The `process:list` command now displays the `hash` and the `key` of each processes.

```
HASH                                         KEY                     
F1NvjpAubLkYpNf26CMNh6vDJvyEKuck1P9Fejinppe4 challenge-invalid-exits 
```