### PR TITLE
Use minor version of the Engine

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "axios": "^0.19.0",
     "chalk": "^2.4.2",
     "cli-ux": "^5.2.1",
+    "debug": "^4.1.1",
     "download-tarball": "^2.0.0",
     "git-clone": "^0.1.0",
     "handlebars": "^4.1.2",

--- a/src/commands/daemon/start.ts
+++ b/src/commands/daemon/start.ts
@@ -29,6 +29,11 @@ export default class Start extends Command {
       default: 'info',
       options: ['debug', 'info', 'warn', 'error', 'fatal', 'panic']
     }),
+    pull: flags.boolean({
+      description: 'Pull the latest image of the given version',
+      default: true,
+      allowNo: true
+    })
   }
 
   async run() {
@@ -39,6 +44,13 @@ export default class Start extends Command {
       this.log('Engine is already started')
       return false
     }
+
+    if (flags.pull) {
+      this.spinner.start(`Pulling version ${flags.version}`)
+      await this.pull(flags.version)
+      this.spinner.stop()
+    }
+
     this.spinner.start('Starting Engine')
     const eventPromise = this.waitForEvent(({Action, Type, from}) =>
       Type === 'container' &&

--- a/src/docker-command.ts
+++ b/src/docker-command.ts
@@ -4,7 +4,8 @@ import {Docker} from 'node-docker-api'
 import {Network} from 'node-docker-api/lib/network'
 import {homedir} from 'os'
 import {join} from 'path'
-import {Readable} from 'stream'
+import {Readable, Stream} from 'stream'
+const debug = require('debug')('docker')
 
 import Command from './root-command'
 
@@ -131,5 +132,16 @@ export default abstract class extends Command {
         }]
       }
     })
+  }
+
+  async pull(tag: string): Promise<object> {
+    const stream = (await this.docker.image.create({}, {
+      fromImage: 'mesg/engine',
+      tag
+    })) as Stream
+    return new Promise((resolve, reject) => stream
+      .on('data', (x: any) => debug(x.toString())) // For some reason we need to listen to the data to have the end event
+      .on('error', reject)
+      .on('end', resolve))
   }
 }

--- a/src/version.ts
+++ b/src/version.ts
@@ -1,3 +1,3 @@
 export default {
-  engine: 'v0.14.2'
+  engine: 'v0.14'
 }


### PR DESCRIPTION
fix https://github.com/mesg-foundation/cli/issues/158

The `daemon:start` command automatically `docker pull` the latest version of the image (with a `--no-pull` to disable it).

Also, the version of the engine used is no based on the minor of the engine