### PR TITLE
Fix issue with zero data

### DIFF
--- a/src/commands/service/execute.ts
+++ b/src/commands/service/execute.ts
@@ -74,7 +74,7 @@ export default class ServiceExecute extends Command {
   convertValue(inputs: any, data: any): any {
     if (!inputs) return {}
     return inputs
-      .filter((x: any) => !!data[x.key])
+      .filter((x: any) => data[x.key] !== undefined && data[x.key] !== null)
       .reduce((prev: any, value: any) => ({
         ...prev,
         [value.key]: this.convert(value.type, data[value.key])


### PR DESCRIPTION
When executing a task with the `--json` flag. If one of the data in the JSON is a negative data like `""`, `0`, `false`, the input will not be sent to the task.

When we want to explicitly send an empty value or 0, this is not possible.

The check is now only on undefined or null instead of any negative value