### PR TITLE
Remove useless account flag in account:XXX commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,9 +95,6 @@
       "daemon": {
         "description": "Manage the Engine"
       },
-      "marketplace": {
-        "description": "Interact with the Marketplace"
-      },
       "account": {
         "description": "Manage accounts"
       }

--- a/src/commands/account/create.ts
+++ b/src/commands/account/create.ts
@@ -1,4 +1,4 @@
-import {WithCredential as Command} from '../../credential-command'
+import {WithCredentialPassphrase as Command} from '../../credential-command'
 
 export default class AccountCreate extends Command {
   static description = 'Create an account'

--- a/src/commands/account/delete.ts
+++ b/src/commands/account/delete.ts
@@ -1,4 +1,4 @@
-import {WithCredential as Command} from '../../credential-command'
+import {WithCredentialPassphrase as Command} from '../../credential-command'
 
 export default class AccountDelete extends Command {
   static description = 'Delete an account'

--- a/src/credential-command.ts
+++ b/src/credential-command.ts
@@ -4,14 +4,26 @@ import {Credential} from 'mesg-js/lib/api'
 
 import Command from './root-command'
 
-export abstract class WithCredential extends Command {
+export abstract class WithCredentialPassphrase extends Command {
   static flags = {
     ...Command.flags,
-    account: flags.string({
-      description: 'Name of the account'
-    }),
     passphrase: flags.string({
       description: 'Passphrase of the account'
+    })
+  }
+
+  async getCredentialPassphrase(): Promise<string> {
+    const {flags} = this.parse()
+    if (flags.passphrase) return flags.passphrase
+    return cli.prompt('Type the passphrase', {type: 'hide'})
+  }
+}
+
+export abstract class WithCredential extends WithCredentialPassphrase {
+  static flags = {
+    ...WithCredentialPassphrase.flags,
+    account: flags.string({
+      description: 'Name of the account'
     })
   }
 
@@ -26,11 +38,5 @@ export abstract class WithCredential extends Command {
     const {flags} = this.parse()
     if (flags.account) return flags.account
     return cli.prompt('Type the name of the account')
-  }
-
-  async getCredentialPassphrase(): Promise<string> {
-    const {flags} = this.parse()
-    if (flags.passphrase) return flags.passphrase
-    return cli.prompt('Type the passphrase', {type: 'hide'})
   }
 }


### PR DESCRIPTION
dependant on https://github.com/mesg-foundation/cli/pull/181
closes https://github.com/mesg-foundation/cli/issues/183

Remove in commands `account:create` and `account:delete` the useless account flag.