### PR TITLE
Update description of service path

### DIFF
--- a/src/commands/service/compile.ts
+++ b/src/commands/service/compile.ts
@@ -17,7 +17,7 @@ export default class ServiceCompile extends Command {
 
   static args = [{
     name: 'SERVICE',
-    description: 'Path or url ([https|mesg]://) of a service',
+    description: 'Path or url of a service',
     default: './'
   }]
 

--- a/src/commands/service/dev.ts
+++ b/src/commands/service/dev.ts
@@ -23,7 +23,7 @@ export default class ServiceDev extends Command {
 
   static args = [{
     name: 'SERVICE',
-    description: 'Path or url ([https|mesg]://) of a service',
+    description: 'Path or url of a service',
     default: './'
   }]
 


### PR DESCRIPTION
The command `service:dev` and `service:compile` doesn't accept `mesg://` urls anymore and the description was not updated