### PR TITLE
Add build in the ci

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -12,6 +12,7 @@ jobs:
       - checkout
       - run: ls
       - run: npm install
+      - run: npm build
       - run: npm test
 
 workflows:


### PR DESCRIPTION
The ts build was not done in the CI so some errors from Typescript are not checked on a new PR