### PR TITLE
Update daemon:start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install -g mesg-cli
 $ mesg-cli COMMAND
 running command...
 $ mesg-cli (-v|--version|version)
-mesg-cli/1.5.0-beta.1 darwin-x64 node-v10.16.0
+mesg-cli/1.5.0-beta.1 darwin-x64 node-v10.16.3
 $ mesg-cli --help [COMMAND]
 USAGE
   $ mesg-cli COMMAND
@@ -144,36 +144,15 @@ USAGE
   $ mesg-cli daemon:start
 
 OPTIONS
-  -h, --help                                       show CLI help
-  -p, --port=port                                  [default: 50052] Port to access the MESG engine
-  -q, --quiet                                      Display only essential information
-  --chain-id=chain-id                              (required) [default: mesg-chain] The id of the chain
-
-  --genesis-time=genesis-time                      (required) [default: 2019-01-01T00:00:00Z] The creation time of the
-                                                   genesis
-
-  --genesis-validator-tx=genesis-validator-tx      (required) The transaction that add the validators to the genesis
-
-  --host=host                                      [default: localhost] Host to access the MESG engine
-
-  --log-force-colors                               Log force colors
-
-  --log-format=(text|json)                         [default: text] Log format
-
-  --log-level=(debug|info|warn|error|fatal|panic)  [default: info] Log level
-
-  --name=name                                      (required) [default: engine] Name of the docker service running the
-                                                   engine
-
-  --p2p-port=p2p-port                              (required) [default: 26656] Port to use for p2p interaction
-
-  --path=path                                      (required) [default: /Users/nico/.mesg] Path to the mesg folder
-
-  --peers=peers                                    The list of persistent peers
-
-  --[no-]pull                                      Pull the latest image of the given version
-
-  --version=version                                (required) [default: v0.15] Version of the Engine to run
+  -h, --help           show CLI help
+  -p, --port=port      [default: 50052] Port to access the MESG engine
+  -q, --quiet          Display only essential information
+  --host=host          [default: localhost] Host to access the MESG engine
+  --name=name          (required) [default: engine] Name of the docker service running the engine
+  --p2p-port=p2p-port  (required) [default: 26656] Port to use for p2p interaction
+  --path=path          (required) [default: /Users/antho/.mesg] Path to the mesg folder
+  --[no-]pull          Pull the latest image of the given version
+  --version=version    (required) [default: v0.15] Version of the Engine to run
 ```
 
 _See code: [src/commands/daemon/start.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/daemon/start.ts)_

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ $ npm install -g mesg-cli
 $ mesg-cli COMMAND
 running command...
 $ mesg-cli (-v|--version|version)
-mesg-cli/1.4.0 darwin-x64 node-v10.16.3
+mesg-cli/1.5.0-beta.1 darwin-x64 node-v10.16.0
 $ mesg-cli --help [COMMAND]
 USAGE
   $ mesg-cli COMMAND
@@ -28,20 +28,14 @@ USAGE
 <!-- usagestop -->
 # Commands
 <!-- commands -->
-* [`mesg-cli account:create`](#mesg-cli-accountcreate)
-* [`mesg-cli account:delete ADDRESS`](#mesg-cli-accountdelete-address)
-* [`mesg-cli account:export ADDRESS`](#mesg-cli-accountexport-address)
-* [`mesg-cli account:import ACCOUNT`](#mesg-cli-accountimport-account)
-* [`mesg-cli account:import-private-key PRIVATE_KEY`](#mesg-cli-accountimport-private-key-private_key)
+* [`mesg-cli account:create ACCOUNT_NAME`](#mesg-cli-accountcreate-account_name)
+* [`mesg-cli account:delete ACCOUNT_NAME`](#mesg-cli-accountdelete-account_name)
 * [`mesg-cli account:list`](#mesg-cli-accountlist)
 * [`mesg-cli daemon:logs`](#mesg-cli-daemonlogs)
 * [`mesg-cli daemon:start`](#mesg-cli-daemonstart)
 * [`mesg-cli daemon:status`](#mesg-cli-daemonstatus)
 * [`mesg-cli daemon:stop`](#mesg-cli-daemonstop)
 * [`mesg-cli help [COMMAND]`](#mesg-cli-help-command)
-* [`mesg-cli marketplace:create-offer SID`](#mesg-cli-marketplacecreate-offer-sid)
-* [`mesg-cli marketplace:publish SERVICE_PATH`](#mesg-cli-marketplacepublish-service_path)
-* [`mesg-cli marketplace:purchase SID OFFER_ID`](#mesg-cli-marketplacepurchase-sid-offer_id)
 * [`mesg-cli process:compile [PROCESS_FILE]`](#mesg-cli-processcompile-process_file)
 * [`mesg-cli process:create DEFINITION`](#mesg-cli-processcreate-definition)
 * [`mesg-cli process:delete PROCESS_HASH...`](#mesg-cli-processdelete-process_hash)
@@ -51,7 +45,6 @@ USAGE
 * [`mesg-cli process:logs PROCESS_HASH`](#mesg-cli-processlogs-process_hash)
 * [`mesg-cli service:compile [SERVICE]`](#mesg-cli-servicecompile-service)
 * [`mesg-cli service:create DEFINITION`](#mesg-cli-servicecreate-definition)
-* [`mesg-cli service:delete SERVICE_HASH...`](#mesg-cli-servicedelete-service_hash)
 * [`mesg-cli service:detail SERVICE_HASH`](#mesg-cli-servicedetail-service_hash)
 * [`mesg-cli service:dev [SERVICE]`](#mesg-cli-servicedev-service)
 * [`mesg-cli service:doc [SERVICE]`](#mesg-cli-servicedoc-service)
@@ -62,13 +55,13 @@ USAGE
 * [`mesg-cli service:start SERVICE_HASH`](#mesg-cli-servicestart-service_hash)
 * [`mesg-cli service:stop INSTANCE_HASH...`](#mesg-cli-servicestop-instance_hash)
 
-## `mesg-cli account:create`
+## `mesg-cli account:create ACCOUNT_NAME`
 
 Create an account
 
 ```
 USAGE
-  $ mesg-cli account:create
+  $ mesg-cli account:create ACCOUNT_NAME
 
 OPTIONS
   -h, --help               show CLI help
@@ -78,15 +71,15 @@ OPTIONS
   --passphrase=passphrase  Passphrase of the account
 ```
 
-_See code: [src/commands/account/create.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/account/create.ts)_
+_See code: [src/commands/account/create.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/account/create.ts)_
 
-## `mesg-cli account:delete ADDRESS`
+## `mesg-cli account:delete ACCOUNT_NAME`
 
 Delete an account
 
 ```
 USAGE
-  $ mesg-cli account:delete ADDRESS
+  $ mesg-cli account:delete ACCOUNT_NAME
 
 OPTIONS
   -h, --help               show CLI help
@@ -96,67 +89,7 @@ OPTIONS
   --passphrase=passphrase  Passphrase of the account
 ```
 
-_See code: [src/commands/account/delete.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/account/delete.ts)_
-
-## `mesg-cli account:export ADDRESS`
-
-Export an existing account
-
-```
-USAGE
-  $ mesg-cli account:export ADDRESS
-
-OPTIONS
-  -h, --help               show CLI help
-  -p, --port=port          [default: 50052] Port to access the MESG engine
-  -q, --quiet              Display only essential information
-  --host=host              [default: localhost] Host to access the MESG engine
-  --passphrase=passphrase  Passphrase of the account
-```
-
-_See code: [src/commands/account/export.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/account/export.ts)_
-
-## `mesg-cli account:import ACCOUNT`
-
-Import an account
-
-```
-USAGE
-  $ mesg-cli account:import ACCOUNT
-
-ARGUMENTS
-  ACCOUNT  Account definition in JSON (could be retrieved with account:export)
-
-OPTIONS
-  -h, --help               show CLI help
-  -p, --port=port          [default: 50052] Port to access the MESG engine
-  -q, --quiet              Display only essential information
-  --host=host              [default: localhost] Host to access the MESG engine
-  --passphrase=passphrase  Passphrase of the account
-```
-
-_See code: [src/commands/account/import.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/account/import.ts)_
-
-## `mesg-cli account:import-private-key PRIVATE_KEY`
-
-Import an account with a private key
-
-```
-USAGE
-  $ mesg-cli account:import-private-key PRIVATE_KEY
-
-ARGUMENTS
-  PRIVATE_KEY  Private key of the account
-
-OPTIONS
-  -h, --help               show CLI help
-  -p, --port=port          [default: 50052] Port to access the MESG engine
-  -q, --quiet              Display only essential information
-  --host=host              [default: localhost] Host to access the MESG engine
-  --passphrase=passphrase  Passphrase of the account
-```
-
-_See code: [src/commands/account/import-private-key.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/account/import-private-key.ts)_
+_See code: [src/commands/account/delete.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/account/delete.ts)_
 
 ## `mesg-cli account:list`
 
@@ -180,7 +113,7 @@ OPTIONS
   --sort=sort        property to sort by (prepend '-' for descending)
 ```
 
-_See code: [src/commands/account/list.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/account/list.ts)_
+_See code: [src/commands/account/list.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/account/list.ts)_
 
 ## `mesg-cli daemon:logs`
 
@@ -200,7 +133,7 @@ OPTIONS
   --tail=tail      [default: -1] Display the last N lines
 ```
 
-_See code: [src/commands/daemon/logs.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/daemon/logs.ts)_
+_See code: [src/commands/daemon/logs.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/daemon/logs.ts)_
 
 ## `mesg-cli daemon:start`
 
@@ -214,20 +147,36 @@ OPTIONS
   -h, --help                                       show CLI help
   -p, --port=port                                  [default: 50052] Port to access the MESG engine
   -q, --quiet                                      Display only essential information
+  --chain-id=chain-id                              (required) [default: mesg-chain] The id of the chain
+
+  --genesis-time=genesis-time                      (required) [default: 2019-01-01T00:00:00Z] The creation time of the
+                                                   genesis
+
+  --genesis-validator-tx=genesis-validator-tx      (required) The transaction that add the validators to the genesis
+
   --host=host                                      [default: localhost] Host to access the MESG engine
+
   --log-force-colors                               Log force colors
+
   --log-format=(text|json)                         [default: text] Log format
+
   --log-level=(debug|info|warn|error|fatal|panic)  [default: info] Log level
 
   --name=name                                      (required) [default: engine] Name of the docker service running the
                                                    engine
+
+  --p2p-port=p2p-port                              (required) [default: 26656] Port to use for p2p interaction
+
+  --path=path                                      (required) [default: /Users/nico/.mesg] Path to the mesg folder
+
+  --peers=peers                                    The list of persistent peers
 
   --[no-]pull                                      Pull the latest image of the given version
 
   --version=version                                (required) [default: v0.15] Version of the Engine to run
 ```
 
-_See code: [src/commands/daemon/start.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/daemon/start.ts)_
+_See code: [src/commands/daemon/start.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/daemon/start.ts)_
 
 ## `mesg-cli daemon:status`
 
@@ -245,7 +194,7 @@ OPTIONS
   --name=name      (required) [default: engine] Name of the docker service running the engine
 ```
 
-_See code: [src/commands/daemon/status.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/daemon/status.ts)_
+_See code: [src/commands/daemon/status.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/daemon/status.ts)_
 
 ## `mesg-cli daemon:stop`
 
@@ -263,7 +212,7 @@ OPTIONS
   --name=name      (required) [default: engine] Name of the docker service running the engine
 ```
 
-_See code: [src/commands/daemon/stop.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/daemon/stop.ts)_
+_See code: [src/commands/daemon/stop.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/daemon/stop.ts)_
 
 ## `mesg-cli help [COMMAND]`
 
@@ -280,76 +229,7 @@ OPTIONS
   --all  see all commands in CLI
 ```
 
-_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.1.6/src/commands/help.ts)_
-
-## `mesg-cli marketplace:create-offer SID`
-
-Create an offer of a service
-
-```
-USAGE
-  $ mesg-cli marketplace:create-offer SID
-
-ARGUMENTS
-  SID  SID of the service
-
-OPTIONS
-  -a, --account=account        Account to use
-  -h, --help                   show CLI help
-  -p, --passphrase=passphrase  Passphrase to unlock the account
-  -p, --port=port              [default: 50052] Port to access the MESG engine
-  -q, --quiet                  Display only essential information
-  --duration=duration          (required) Duration (in seconds)
-  --host=host                  [default: localhost] Host to access the MESG engine
-  --price=price                (required) Price (in MESG tokens)
-```
-
-_See code: [src/commands/marketplace/create-offer.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/marketplace/create-offer.ts)_
-
-## `mesg-cli marketplace:publish SERVICE_PATH`
-
-Publish a service
-
-```
-USAGE
-  $ mesg-cli marketplace:publish SERVICE_PATH
-
-ARGUMENTS
-  SERVICE_PATH  [default: ./] Path of the service
-
-OPTIONS
-  -a, --account=account        Account to use
-  -h, --help                   show CLI help
-  -p, --passphrase=passphrase  Passphrase to unlock the account
-  -p, --port=port              [default: 50052] Port to access the MESG engine
-  -q, --quiet                  Display only essential information
-  --host=host                  [default: localhost] Host to access the MESG engine
-```
-
-_See code: [src/commands/marketplace/publish.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/marketplace/publish.ts)_
-
-## `mesg-cli marketplace:purchase SID OFFER_ID`
-
-Purchase a service
-
-```
-USAGE
-  $ mesg-cli marketplace:purchase SID OFFER_ID
-
-ARGUMENTS
-  SID       ID of the service
-  OFFER_ID  ID of the offer
-
-OPTIONS
-  -a, --account=account        Account to use
-  -h, --help                   show CLI help
-  -p, --passphrase=passphrase  Passphrase to unlock the account
-  -p, --port=port              [default: 50052] Port to access the MESG engine
-  -q, --quiet                  Display only essential information
-  --host=host                  [default: localhost] Host to access the MESG engine
-```
-
-_See code: [src/commands/marketplace/purchase.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/marketplace/purchase.ts)_
+_See code: [@oclif/plugin-help](https://github.com/oclif/plugin-help/blob/v2.2.1/src/commands/help.ts)_
 
 ## `mesg-cli process:compile [PROCESS_FILE]`
 
@@ -363,15 +243,17 @@ ARGUMENTS
   PROCESS_FILE  Path of a process file
 
 OPTIONS
-  -h, --help       show CLI help
-  -p, --port=port  [default: 50052] Port to access the MESG engine
-  -q, --quiet      Display only essential information
-  --dev            compile the process and automatically deploy and start all the services
-  --env=FOO=BAR    Set environment variables
-  --host=host      [default: localhost] Host to access the MESG engine
+  -h, --help               show CLI help
+  -p, --port=port          [default: 50052] Port to access the MESG engine
+  -q, --quiet              Display only essential information
+  --account=account        Name of the account
+  --dev                    compile the process and automatically deploy and start all the services
+  --env=FOO=BAR            Set environment variables
+  --host=host              [default: localhost] Host to access the MESG engine
+  --passphrase=passphrase  Passphrase of the account
 ```
 
-_See code: [src/commands/process/compile.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/process/compile.ts)_
+_See code: [src/commands/process/compile.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/process/compile.ts)_
 
 ## `mesg-cli process:create DEFINITION`
 
@@ -391,7 +273,7 @@ OPTIONS
   --host=host      [default: localhost] Host to access the MESG engine
 ```
 
-_See code: [src/commands/process/create.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/process/create.ts)_
+_See code: [src/commands/process/create.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/process/create.ts)_
 
 ## `mesg-cli process:delete PROCESS_HASH...`
 
@@ -409,7 +291,7 @@ OPTIONS
   --host=host      [default: localhost] Host to access the MESG engine
 ```
 
-_See code: [src/commands/process/delete.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/process/delete.ts)_
+_See code: [src/commands/process/delete.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/process/delete.ts)_
 
 ## `mesg-cli process:detail PROCESS_HASH`
 
@@ -426,7 +308,7 @@ OPTIONS
   --host=host      [default: localhost] Host to access the MESG engine
 ```
 
-_See code: [src/commands/process/detail.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/process/detail.ts)_
+_See code: [src/commands/process/detail.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/process/detail.ts)_
 
 ## `mesg-cli process:dev [PROCESS]`
 
@@ -440,15 +322,17 @@ ARGUMENTS
   PROCESS  [default: ./] Path of the process
 
 OPTIONS
-  -h, --help       show CLI help
-  -p, --port=port  [default: 50052] Port to access the MESG engine
-  -q, --quiet      Display only essential information
-  --dev            compile the process and automatically deploy and start all the services
-  --env=FOO=BAR    Set environment variables
-  --host=host      [default: localhost] Host to access the MESG engine
+  -h, --help               show CLI help
+  -p, --port=port          [default: 50052] Port to access the MESG engine
+  -q, --quiet              Display only essential information
+  --account=account        Name of the account
+  --dev                    compile the process and automatically deploy and start all the services
+  --env=FOO=BAR            Set environment variables
+  --host=host              [default: localhost] Host to access the MESG engine
+  --passphrase=passphrase  Passphrase of the account
 ```
 
-_See code: [src/commands/process/dev.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/process/dev.ts)_
+_See code: [src/commands/process/dev.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/process/dev.ts)_
 
 ## `mesg-cli process:list`
 
@@ -472,7 +356,7 @@ OPTIONS
   --sort=sort        property to sort by (prepend '-' for descending)
 ```
 
-_See code: [src/commands/process/list.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/process/list.ts)_
+_See code: [src/commands/process/list.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/process/list.ts)_
 
 ## `mesg-cli process:logs PROCESS_HASH`
 
@@ -489,7 +373,7 @@ OPTIONS
   --host=host      [default: localhost] Host to access the MESG engine
 ```
 
-_See code: [src/commands/process/logs.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/process/logs.ts)_
+_See code: [src/commands/process/logs.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/process/logs.ts)_
 
 ## `mesg-cli service:compile [SERVICE]`
 
@@ -500,7 +384,7 @@ USAGE
   $ mesg-cli service:compile [SERVICE]
 
 ARGUMENTS
-  SERVICE  [default: ./] Path or url ([https|mesg]://) of a service
+  SERVICE  [default: ./] Path or url of a service
 
 OPTIONS
   -h, --help       show CLI help
@@ -509,7 +393,7 @@ OPTIONS
   --host=host      [default: localhost] Host to access the MESG engine
 ```
 
-_See code: [src/commands/service/compile.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/compile.ts)_
+_See code: [src/commands/service/compile.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/service/compile.ts)_
 
 ## `mesg-cli service:create DEFINITION`
 
@@ -523,32 +407,16 @@ ARGUMENTS
   DEFINITION  Service's definition. Use service:compile first to build service definition
 
 OPTIONS
-  -h, --help       show CLI help
-  -p, --port=port  [default: 50052] Port to access the MESG engine
-  -q, --quiet      Display only essential information
-  --host=host      [default: localhost] Host to access the MESG engine
-  --start          Automatically start the service once created
+  -h, --help               show CLI help
+  -p, --port=port          [default: 50052] Port to access the MESG engine
+  -q, --quiet              Display only essential information
+  --account=account        Name of the account
+  --host=host              [default: localhost] Host to access the MESG engine
+  --passphrase=passphrase  Passphrase of the account
+  --start                  Automatically start the service once created
 ```
 
-_See code: [src/commands/service/create.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/create.ts)_
-
-## `mesg-cli service:delete SERVICE_HASH...`
-
-Delete one or many services
-
-```
-USAGE
-  $ mesg-cli service:delete SERVICE_HASH...
-
-OPTIONS
-  -h, --help       show CLI help
-  -p, --port=port  [default: 50052] Port to access the MESG engine
-  -q, --quiet      Display only essential information
-  --confirm        Confirm deletion
-  --host=host      [default: localhost] Host to access the MESG engine
-```
-
-_See code: [src/commands/service/delete.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/delete.ts)_
+_See code: [src/commands/service/create.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/service/create.ts)_
 
 ## `mesg-cli service:detail SERVICE_HASH`
 
@@ -565,7 +433,7 @@ OPTIONS
   --host=host      [default: localhost] Host to access the MESG engine
 ```
 
-_See code: [src/commands/service/detail.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/detail.ts)_
+_See code: [src/commands/service/detail.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/service/detail.ts)_
 
 ## `mesg-cli service:dev [SERVICE]`
 
@@ -576,18 +444,20 @@ USAGE
   $ mesg-cli service:dev [SERVICE]
 
 ARGUMENTS
-  SERVICE  [default: ./] Path or url ([https|mesg]://) of a service
+  SERVICE  [default: ./] Path or url of a service
 
 OPTIONS
-  -h, --help       show CLI help
-  -p, --port=port  [default: 50052] Port to access the MESG engine
-  -q, --quiet      Display only essential information
-  --env=FOO=BAR    Set environment variables
-  --host=host      [default: localhost] Host to access the MESG engine
-  --start          Automatically start the service once created
+  -h, --help               show CLI help
+  -p, --port=port          [default: 50052] Port to access the MESG engine
+  -q, --quiet              Display only essential information
+  --account=account        Name of the account
+  --env=FOO=BAR            Set environment variables
+  --host=host              [default: localhost] Host to access the MESG engine
+  --passphrase=passphrase  Passphrase of the account
+  --start                  Automatically start the service once created
 ```
 
-_See code: [src/commands/service/dev.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/dev.ts)_
+_See code: [src/commands/service/dev.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/service/dev.ts)_
 
 ## `mesg-cli service:doc [SERVICE]`
 
@@ -608,7 +478,7 @@ OPTIONS
   --host=host      [default: localhost] Host to access the MESG engine
 ```
 
-_See code: [src/commands/service/doc.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/doc.ts)_
+_See code: [src/commands/service/doc.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/service/doc.ts)_
 
 ## `mesg-cli service:execute INSTANCE_HASH TASK`
 
@@ -631,7 +501,7 @@ OPTIONS
   --host=host           [default: localhost] Host to access the MESG engine
 ```
 
-_See code: [src/commands/service/execute.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/execute.ts)_
+_See code: [src/commands/service/execute.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/service/execute.ts)_
 
 ## `mesg-cli service:init DIR`
 
@@ -652,7 +522,7 @@ OPTIONS
   --host=host              [default: localhost] Host to access the MESG engine
 ```
 
-_See code: [src/commands/service/init.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/init.ts)_
+_See code: [src/commands/service/init.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/service/init.ts)_
 
 ## `mesg-cli service:list`
 
@@ -676,7 +546,7 @@ OPTIONS
   --sort=sort        property to sort by (prepend '-' for descending)
 ```
 
-_See code: [src/commands/service/list.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/list.ts)_
+_See code: [src/commands/service/list.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/service/list.ts)_
 
 ## `mesg-cli service:logs INSTANCE_HASH`
 
@@ -699,7 +569,7 @@ OPTIONS
   --task=task      Display a specific task results
 ```
 
-_See code: [src/commands/service/logs.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/logs.ts)_
+_See code: [src/commands/service/logs.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/service/logs.ts)_
 
 ## `mesg-cli service:start SERVICE_HASH`
 
@@ -717,7 +587,7 @@ OPTIONS
   --host=host      [default: localhost] Host to access the MESG engine
 ```
 
-_See code: [src/commands/service/start.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/start.ts)_
+_See code: [src/commands/service/start.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/service/start.ts)_
 
 ## `mesg-cli service:stop INSTANCE_HASH...`
 
@@ -736,5 +606,5 @@ OPTIONS
   --host=host      [default: localhost] Host to access the MESG engine
 ```
 
-_See code: [src/commands/service/stop.ts](https://github.com/mesg-foundation/cli/blob/v1.4.0/src/commands/service/stop.ts)_
+_See code: [src/commands/service/stop.ts](https://github.com/mesg-foundation/cli/blob/v1.5.0-beta.1/src/commands/service/stop.ts)_
 <!-- commandsstop -->

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "mesg-cli",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "mesg-cli",
   "description": "MESG CLI",
-  "version": "1.4.0",
+  "version": "1.5.0-beta.1",
   "author": "Anthony ESTEBE @antho1404",
   "bin": {
     "mesg-cli": "./bin/run"

--- a/src/commands/daemon/start.ts
+++ b/src/commands/daemon/start.ts
@@ -27,37 +27,6 @@ export default class Start extends Command {
       default: true,
       allowNo: true
     }),
-    'log-force-colors': flags.boolean({
-      description: 'Log force colors',
-      default: false
-    }),
-    'log-format': flags.enum({
-      description: 'Log format',
-      default: 'text',
-      options: ['text', 'json']
-    }),
-    'log-level': flags.enum({
-      description: 'Log level',
-      default: 'info',
-      options: ['debug', 'info', 'warn', 'error', 'fatal', 'panic']
-    }),
-    'genesis-validator-tx': flags.string({
-      description: 'The transaction that add the validators to the genesis',
-      required: true,
-    }),
-    peers: flags.string({
-      description: 'The list of persistent peers',
-    }),
-    'chain-id': flags.string({
-      description: 'The id of the chain',
-      default: 'mesg-chain',
-      required: true,
-    }),
-    'genesis-time': flags.string({
-      description: 'The creation time of the genesis',
-      default: '2019-01-01T00:00:00Z',
-      required: true,
-    }),
     'p2p-port': flags.integer({
       description: 'Port to use for p2p interaction',
       default: 26656,
@@ -87,17 +56,9 @@ export default class Start extends Command {
       from === `mesg/engine:${flags.version}`
     )
     const network = await this.getOrCreateNetwork({name: flags.name})
-    const tendermintNetwork = await this.getOrCreateNetwork({name: 'mesg-tendermint'})
-    await this.createEngineService(network, tendermintNetwork, {
+    await this.createEngineService(network, {
       name: flags.name,
       version: flags.version,
-      colors: flags['log-force-colors'],
-      format: flags['log-format'],
-      level: flags['log-level'],
-      genesisValidatorTx: flags['genesis-validator-tx'],
-      genesisTime: flags['genesis-time'],
-      chainId: flags['chain-id'],
-      persistentPeers: flags.peers || '',
       path: flags.path,
       port: flags.port,
       p2pPort: flags['p2p-port'],

--- a/src/docker-command.ts
+++ b/src/docker-command.ts
@@ -23,16 +23,9 @@ interface ListOption {
 
 interface ServiceOption {
   name: string
-  format: string
-  level: string
-  colors: boolean
   version: string
   port: number
   path: string
-  genesisValidatorTx: string
-  genesisTime: string
-  chainId: string
-  persistentPeers: string
   p2pPort: number
 }
 
@@ -87,7 +80,7 @@ export default abstract class extends Command {
     })
   }
 
-  async createEngineService(network: Network, tendermintNetwork: Network, options: ServiceOption) {
+  async createEngineService(network: Network, options: ServiceOption) {
     const image = `mesg/engine:${options.version}`
     if (!existsSync(options.path)) {
       mkdirSync(options.path)
@@ -105,14 +98,7 @@ export default abstract class extends Command {
             'com.docker.stack.namespace': options.name
           },
           Env: [
-            `MESG_LOG_FORMAT=${options.format}`,
-            `MESG_LOG_LEVEL=${options.level}`,
-            `MESG_LOG_FORCECOLORS=${options.colors}`,
             `MESG_NAME=${options.name}`,
-            `MESG_TENDERMINT_P2P_PERSISTENTPEERS=${options.persistentPeers}`,
-            `MESG_COSMOS_CHAINID=${options.chainId}`,
-            `MESG_COSMOS_GENESISVALIDATORTX=${options.genesisValidatorTx}`,
-            `MESG_COSMOS_GENESISTIME=${options.genesisTime}`,
           ],
           Mounts: [{
             Source: '/var/run/docker.sock',
@@ -127,10 +113,6 @@ export default abstract class extends Command {
         Networks: [
           {
             Target: network.id,
-            Alias: options.name,
-          },
-          {
-            Target: tendermintNetwork.id,
             Alias: options.name,
           },
         ]


### PR DESCRIPTION
Update `daemon:start` command to be compatible with the new options of the engine.
Some flags are removed (because moved in the mesg config file)

Add the possibility to configure the host path and the p2p port