### PR TITLE
Add instance hash to service dev command

### DIFF
--- a/src/commands/service/dev.ts
+++ b/src/commands/service/dev.ts
@@ -40,7 +40,7 @@ export default class ServiceDev extends Command {
     const instanceHash = await this.startService(serviceHash, flags.env)
     this.spinner.status = 'fetching logs'
     const stream = await ServiceLog.run([base58.encode(instanceHash)])
-    this.spinner.stop('ready')
+    this.spinner.stop(base58.encode(instanceHash))
 
     process.once('SIGINT', async () => {
       stream.destroy()


### PR DESCRIPTION
The command `service:dev` doesn't display the instance running. Now that we removed the possibility to delete a service, it is really annoying because we cannot use the sid as alias.

At least with this PR we can now have the instance hash of the service in order to execute tasks.